### PR TITLE
Aic Emulator App and YML Aic Profile Generator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,12 @@ project (vhal-client VERSION 0.1 DESCRIPTION "VHAL Client library written in C++
 
 option(BUILD_EXAMPLES "Build examples?" ON)
 
+option(BUILD_EMULATOR_APP "Enable AIC Emulator build for ICR unit testing?" OFF)
+
+if (BUILD_EMULATOR_APP )
+  message(STATUS "BUILD_EMULATOR_APP enabled")
+endif()
+
 message(STATUS "Project name: ${PROJECT_NAME}")
 
 
@@ -39,6 +45,10 @@ add_subdirectory (include/libvhal)
 if (BUILD_EXAMPLES)
   add_subdirectory (examples)
 endif()
+if (BUILD_EMULATOR_APP)
+  add_subdirectory (aic-emu)
+endif()
+
 
 #Add pkg-config file
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pkg-config.pc.cmake" ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)

--- a/aic-emu/AicEmu.cc
+++ b/aic-emu/AicEmu.cc
@@ -1,0 +1,137 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <memory>
+#include "CmdHandler.h"
+
+struct AicConfigData_t
+{
+    std::string ymlFileName;
+    std::string contentFileName;
+    std::string deviceString;
+    AicSocketData_t socketInfo;
+};
+
+void Usage()
+{
+    std::cout << "Usage: aic-emu <mandatory options> [non-mandatory options] " << std::endl;
+    std::cout << "\nMandatory options:" << std::endl;
+    std::cout << "  --cmd <yml file path>  : Path of YML file containing AiC cmd sequence" << std::endl;
+    std::cout << "  --content <clip path>  : Path of clip to serve as content" << std::endl;
+    std::cout << "  --hwc-sock <socketpath>: Path of Unix Socket file" << std::endl;
+    std::cout << "\nNon-Mandatory options:" << std::endl;
+    std::cout << "  --device <device path> : Device path. Default /dev/dri/renderD128" << std::endl;
+    std::cout << "  --help, -h             : Print this help and exit" << std::endl;
+    return;
+}
+
+int ParseArgs(AicConfigData_t& config, int argc, char** argv)
+{
+    int idx;
+    for (idx = 1; idx < argc; ++idx)
+    {
+        if (std::string("-h") == argv[idx] || std::string("--help") == argv[idx])
+        {
+            Usage();
+            exit(0);
+        }
+        else if (std::string("--cmd") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.ymlFileName = std::string(argv[idx]);
+        }
+        else if (std::string("--content") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.contentFileName = std::string(argv[idx]);
+        }
+        else if (std::string("--device") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.deviceString = std::string(argv[idx]);
+        }
+        else if (std::string("--hwc-sock") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.socketInfo.hwc_sock = std::string(argv[idx]);
+
+            //Make rest of fields 0
+            config.socketInfo.session_id = 0;
+            config.socketInfo.user_id = 0;
+            config.socketInfo.android_instance_id = 0;
+        }
+        else
+        {
+            break;
+        }
+    }
+
+    if (config.ymlFileName.empty())
+    {
+        std::cout << "Specification of YMLfile with AiC commands is mandatory" <<std::endl;
+        Usage();
+        return AICS_ERR_INVALID_ARGS;
+    }
+
+    if (config.contentFileName.empty())
+    {
+        std::cout << "Specification of Content file is mandatory" <<std::endl;
+        Usage();
+        return AICS_ERR_INVALID_ARGS;
+    }
+
+    if (config.socketInfo.hwc_sock.empty())
+    {
+        std::cout << "Specification of Unix Socket file path is mandatory" <<std::endl;
+        Usage();
+        return AICS_ERR_INVALID_ARGS;
+    }
+
+    return AICS_ERR_NONE;
+}
+
+int main(int argc, char** argv)
+{
+    int status = AICS_ERR_NONE;
+
+    AicConfigData_t config;
+    status = ParseArgs(config, argc, argv);
+    CHECK_STATUS(status);
+
+    auto handler = std::make_unique<CmdHandler>(config.ymlFileName, config.contentFileName, &config.socketInfo);
+    status = handler->Init();
+    CHECK_STATUS(status);
+
+    int count = 0;
+    do{
+       status = handler->ProcessNextEntry();
+       if (status != AICS_ERR_EOF)
+           CHECK_STATUS(status);
+       count++;
+    }
+    while (status == AICS_ERR_NONE);
+
+    std::cout << "End of Run: " << count << " events processed" << std::endl;
+
+    return 0;
+}

--- a/aic-emu/CMakeLists.txt
+++ b/aic-emu/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (C) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+find_package(PkgConfig REQUIRED)
+find_package(Threads REQUIRED)
+find_package(yaml-cpp REQUIRED)
+
+Message(status "  " Build Aic Emu!)
+set (aic_executable "aic-emu")
+
+add_executable( ${aic_executable} AicEmu.cc CmdHandler.cc YmlParser.cc GfxHandler.cc SocketServer.cc)
+
+target_include_directories (${aic_executable} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+target_link_libraries (${aic_executable} LINK_PUBLIC  Threads::Threads yaml-cpp)
+
+install(TARGETS ${aic_executable}
+        DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})

--- a/aic-emu/CmdHandler.cc
+++ b/aic-emu/CmdHandler.cc
@@ -1,0 +1,582 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "CmdHandler.h"
+#include <unistd.h>
+
+using namespace aic_emu::server;
+
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::system_clock;
+
+CmdHandler::CmdHandler(std::string ymlFile, std::string inputFile, AicSocketData_t* info):
+    m_ymlFileName(ymlFile),
+    m_inputFileName(inputFile),
+    m_props(nullptr),
+    m_lastDispReqSentTS(0),
+    m_lastDispReqYmlTS(0),
+    m_firstDispReqSentTS(0)
+{
+    if (info)
+    {
+        std::string path = info->hwc_sock;
+        if (path.find("/hwc-sock") == std::string::npos)
+            return;
+
+        size_t pos = path.find("/hwc-sock");
+        m_UnixConnInfo.socket_dir = path.substr(0, pos);
+
+        if (getenv("K8S_ENV") == NULL || strcmp(getenv("K8S_ENV"), "true") != 0) {
+            // docker env
+            m_UnixConnInfo.android_instance_id = info->session_id;
+        }
+        else
+        {
+            // k8s env
+            m_UnixConnInfo.android_instance_id = -1; //dont need id for k8s env
+        }
+    }
+}
+
+CmdHandler::~CmdHandler()
+{
+    if (m_inputStream.is_open())
+        m_inputStream.close();
+}
+
+int CmdHandler::Init()
+{
+    CHECK_STATUS(InitYmlParser());
+
+    CHECK_STATUS(InitGfxSurfaceHandler());
+
+    CHECK_STATUS(InitSocket());
+
+    return AICS_ERR_NONE;
+}
+
+int CmdHandler::InitSocket()
+{
+    auto sockPath = m_UnixConnInfo.socket_dir;
+    if (sockPath.length() == 0) {
+        std::cout << "Empty or invalid socket_dir path" << std::endl;
+        return AICS_ERR_SOCKET_INIT;
+    }
+    else
+    {
+        sockPath += HWC_UNIX_SOCKET;
+        if (m_UnixConnInfo.android_instance_id >= 0) {
+            sockPath += std::to_string(m_UnixConnInfo.android_instance_id);
+        }
+    }
+
+    //Creating interface to communicate to libvhal
+    m_socket = std::make_unique<UnixServerSocket>(std::move(sockPath));
+    if (!m_socket)
+        return AICS_ERR_SOCKET_INIT;
+
+    try {
+        //Block till client connects
+        m_socket->AwaitConnection();
+    }
+    catch (std::system_error& e) {
+        return AICS_ERR_SOCKET_CONNECT;
+    }
+
+    return AICS_ERR_NONE;
+}
+
+int CmdHandler::WriteIntoSocket(void* data, uint32_t sizeInBytes)
+{
+    if (!m_socket)
+        return AICS_ERR_SOCKET_INIT;
+
+    if (!m_socket->Connected())
+        return AICS_ERR_SOCKET_CONNECT;
+
+    if (!data)
+        return AICS_ERR_NULL_PTR;
+
+    auto [bytes, errMsg] = m_socket->Send((uint8_t *)data, sizeInBytes);
+    if (bytes == -1)
+    {
+        std::cout << "WriteSocket call failed with error: " << errMsg << std::endl;
+        return AICS_ERR_SOCKET;
+    }
+    return AICS_ERR_NONE;
+}
+
+int CmdHandler::ReadFromSocket(void* dst, uint32_t sizeInBytes)
+{
+    if (!m_socket)
+        return AICS_ERR_SOCKET_INIT;
+
+    if (!m_socket->Connected())
+        return AICS_ERR_SOCKET_CONNECT;
+
+    if (!dst)
+        return AICS_ERR_NULL_PTR;
+
+    auto [bytes, errMsg] = m_socket->Recv((uint8_t*) dst, sizeInBytes);
+    if (bytes == -1)
+    {
+        std::cout << "WriteSocket call failed with error: " << errMsg << std::endl;
+        return AICS_ERR_SOCKET;
+    }
+
+    return AICS_ERR_NONE;
+}
+
+int CmdHandler::SendFDs(boData_t* bo_data)
+{
+    AIC_LOG();
+
+    if (!bo_data)
+        return AICS_ERR_NULL_PTR;
+
+    int fds[MAX_FD_SUPPORTED];
+    fds[0] = bo_data->fd;
+
+    auto [bytes, errMsg] = m_socket->SendMsg(fds, sizeof(fds));
+
+    if (bytes < 0)
+    {
+        std::cout << "SendMsg socket call failed with error: " << errMsg << std::endl;
+        return AICS_ERR_SOCKET;
+    }
+
+    return AICS_ERR_NONE;
+}
+
+void CmdHandler::ManageDisplayReqTime(AicEventMetadataPtr& metadata)
+{
+    if (m_lastDispReqSentTS == 0)
+        return;
+
+    long int waitTime = metadata->timeStampUs - m_lastDispReqYmlTS;
+
+    if (waitTime > 1000000) //Clamp to 1s
+        waitTime = 1000000;
+
+    auto curTime = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+
+    long int remainingWaitUs = waitTime - ((long int)curTime - m_lastDispReqSentTS);
+
+    if (remainingWaitUs > 0)
+        usleep(remainingWaitUs);
+}
+
+int CmdHandler::Xchng_DisplayRequest(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata)
+{
+    // send display_event_t + buffer_info_t (+ optional display_control_t)
+
+    if (payload.empty())
+        return AICS_ERR_PAYLOAD_EMPTY;
+
+    auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+
+    // Check if payload data is consistent
+    int requestSize = evInfo->event.size - sizeof(display_event_t);
+    bool hasCtrl = (requestSize == (sizeof(buffer_info_t) + sizeof(display_control_t)));
+    if (hasCtrl && payload.size() != 2)
+    {
+        std::cout << "Error: display_control_t data specified but missing from parser" << std::endl;
+        return AICS_ERR_UNKNOWN;
+    }
+
+    AIC_LOG();
+
+    // Prepare frame for display
+    int status = 0;
+    boData_t* bo_data = m_gfx.GetBo(evInfo->info.remote_handle);
+    if (!bo_data)
+        return AICS_ERR_NULL_PTR;
+
+    SurfaceParams_t surf = bo_data->surf;
+    size_t sizeToRead = surf.width * surf.height * surf.pixelSize;
+    uint8_t* pFrame = new uint8_t[sizeToRead];
+
+    status = GetOneFrame(pFrame, sizeToRead);
+    CHECK_STATUS(status);
+
+    // Copy data to GPU memory indicated by file-descriptor
+    status = m_gfx.Copy(bo_data, pFrame);
+    CHECK_STATUS(status);
+
+    // Maintain fps
+    ManageDisplayReqTime(metadata);
+
+    // Write Data to sockets
+    AIC_LOG();
+    status = WriteIntoSocket(&evInfo->event, sizeof(display_event_t));
+    CHECK_STATUS(status);
+    status = WriteIntoSocket(&evInfo->info, sizeof(buffer_info_t));
+    CHECK_STATUS(status);
+    if (hasCtrl)
+    {
+        auto ctrl = std::static_pointer_cast<display_control_t, void>(payload[1]);
+        status = WriteIntoSocket(ctrl.get(), sizeof(display_control_t));
+        CHECK_STATUS(status);
+    }
+
+    // Clean up and Timing book-keeping
+    if (pFrame)
+        delete[] pFrame;
+
+    m_lastDispReqYmlTS  = metadata->timeStampUs;
+    m_lastDispReqSentTS = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+    if (m_firstDispReqSentTS == 0)
+        m_firstDispReqSentTS = m_lastDispReqSentTS;
+
+    return AICS_ERR_NONE;
+}
+
+
+int CmdHandler::DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata)
+{
+    int status = AICS_ERR_NONE;
+
+    if (payload.empty())
+        return AICS_ERR_PAYLOAD_EMPTY;
+
+    if (metadata->direction == DIRECTION_SEND)
+    {
+        switch (metadata->eventType)
+        {
+        case VHAL_DD_EVENT_DISPINFO_REQ:
+        case VHAL_DD_EVENT_DISPPORT_REQ:
+        {
+            AIC_LOG();
+
+            //send display_event_t
+            auto event = std::static_pointer_cast<display_event_t>(payload[0]);
+            status = WriteIntoSocket(event.get(), sizeof(display_event_t));
+            CHECK_STATUS(status);
+            break;
+        }
+        case VHAL_DD_EVENT_CREATE_BUFFER:
+        {
+            AIC_LOG();
+            //send display_event_t + buffer_info_t + cros_gralloc_handle + Special FDs msg
+            auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+            auto grallocHandle = std::static_pointer_cast<cros_gralloc_handle, void>(payload[1]);
+            m_props = grallocHandle;
+            std::cout << "width = " << m_props->width << " , height = " << m_props->height << std::endl;
+            std::cout << "fds = " << m_props->base.numFds << ", numInts - " << m_props->base.numInts << std::endl;
+
+            SurfaceParams_t surf;
+            m_gfx.DetermineSurfaceParams(surf, m_props->width, m_props->height, m_props->format);
+
+            status = m_gfx.AllocateBo(surf, evInfo->info.remote_handle);
+            CHECK_STATUS((int)status);
+
+            //Write all msgs to socket
+            AIC_LOG();
+            status = WriteIntoSocket(&evInfo->event, sizeof(display_event_t));
+            CHECK_STATUS(status);
+            status = WriteIntoSocket(&evInfo->info, sizeof(buffer_info_t));
+            CHECK_STATUS(status);
+            status = WriteIntoSocket(payload[1].get(), sizeof(cros_gralloc_handle));
+            CHECK_STATUS(status);
+
+            //Prepare and send msg with FDs
+            AIC_LOG();
+            boData_t* bo_data = m_gfx.GetBo(evInfo->info.remote_handle);
+            status = SendFDs(bo_data);
+            CHECK_STATUS(status);
+            break;
+        }
+        case VHAL_DD_EVENT_REMOVE_BUFFER:
+        {
+            AIC_LOG();
+            //send display_event_t + buffer_info_t
+            auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+
+            status = WriteIntoSocket(&evInfo->event, sizeof(display_event_t));
+            CHECK_STATUS(status);
+            status = WriteIntoSocket(&evInfo->info, sizeof(buffer_info_t));
+            CHECK_STATUS(status);
+
+            status = m_gfx.ClearBo(evInfo->info.remote_handle);
+            CHECK_STATUS(status);
+            break;
+        }
+        case VHAL_DD_EVENT_DISPLAY_REQ:
+        {
+            AIC_LOG();
+            status = Xchng_DisplayRequest(payload, metadata);
+            CHECK_STATUS(status);
+            break;
+        }
+        default:
+        {
+            AIC_LOG();
+            return AICS_ERR_BAD_METADATA;
+        }
+        }//switch
+    }
+    else if (metadata->direction == DIRECTION_RECEIVE)
+    {
+        switch (metadata->eventType)
+        {
+        case VHAL_DD_EVENT_DISPINFO_ACK:
+        case VHAL_DD_EVENT_SETUP_RESOLUTION:
+        {
+            AIC_LOG();
+            //recv display_info_t
+            display_info_t dispInfo;
+            int status = ReadFromSocket(&dispInfo, sizeof(display_info_t));
+            CHECK_STATUS(status);
+            break;
+        }
+        case VHAL_DD_EVENT_DISPLAY_ACK:
+        {
+            AIC_LOG();
+            buffer_info_event_t dispInfoEvent;
+            int status = ReadFromSocket(&dispInfoEvent, sizeof(buffer_info_event_t));
+            CHECK_STATUS(status);
+            break;
+        }
+        case VHAL_DD_EVENT_SET_VIDEO_ALPHA_REQ:
+        {
+            AIC_LOG();
+            display_set_video_alpha_event_t alphaEvent;
+            int status = ReadFromSocket(&alphaEvent, sizeof(display_set_video_alpha_event_t));
+            CHECK_STATUS(status);
+            break;
+        }
+        default:
+        {
+            AIC_LOG();
+            return AICS_ERR_BAD_METADATA;
+        }
+        }
+    }
+    else
+    {
+        AIC_LOG();
+        return AICS_ERR_BAD_METADATA;
+    }
+    std::cout << "==================" << std::endl;
+
+    return AICS_ERR_NONE;
+}
+
+
+int CmdHandler::ProcessNextEntry()
+{
+    if (m_nextNode == m_ymlDocs.end())
+        return AICS_ERR_EOF;
+
+    AIC_LOG();
+    std::vector<std::shared_ptr<void>> payload;
+    AicEventMetadataPtr metadata = std::make_shared<AicEventMetadata_t>();
+
+    try {
+        DecodeNode(*m_nextNode, payload, metadata);
+        std::cout << "\tpayload size in count: " << payload.size() << std::endl;
+    }
+    catch(...) {
+        std::cout << "Exception in Parsing  " << m_ymlFileName << std::endl;
+        m_nextNode++;
+        return AICS_YML_PARSER_ERR;
+    }
+
+    m_nextNode++;
+
+    return DataExchange(payload, metadata);
+}
+
+
+int CmdHandler::DecodeNode(YAML::Node& rootNode, std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata)
+{
+    if (!rootNode.IsMap())
+        return AICS_YML_PARSER_ERR;
+
+    auto node = rootNode["event"];
+
+    //---Process Metadata
+    if (metadata == nullptr)
+        return AICS_ERR_NULL_PTR;
+
+    if (node["metadata"] && node["metadata"].IsMap())
+        YAML::convert<AicEventMetadataPtr>::decode(node["metadata"], metadata);
+    else
+        return AICS_YML_PARSER_ERR;
+
+    std::cout << "{id, type, direction, timestamp} : {" << metadata->eventId << ", " << metadata->eventType << ", " << metadata->direction << ", " << metadata->timeStampUs << "}\n";
+
+    //---Get Event Info
+    //Only one of below events is expected
+    switch (metadata->eventType)
+    {
+    case VHAL_DD_EVENT_DISPINFO_REQ:
+    case VHAL_DD_EVENT_DISPPORT_REQ:
+    {
+        //Both cases involve display_event_t
+        auto mptr = std::make_shared<display_event_t>();
+        YAML::convert<DisplayEventPtr>::decode(node["display_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+        break;
+    }
+
+    case VHAL_DD_EVENT_DISPINFO_ACK:
+    case VHAL_DD_EVENT_SETUP_RESOLUTION:
+    {
+        //Both cases involve display_info_event_t
+        auto mptr = std::make_shared<display_info_event_t>();
+        YAML::convert<DisplayInfoEventPtr>::decode(node["display_info_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+        break;
+    }
+
+    case VHAL_DD_EVENT_CREATE_BUFFER:
+    {
+        auto mptr_headers = std::make_shared<buffer_info_event_t>();
+        YAML::Node createBufferNode = node["buffer_info_event_t"];
+        YAML::convert<BufferInfoEventPtr>::decode(createBufferNode, mptr_headers);
+        std::shared_ptr<void> v_mptrHeaders = mptr_headers;
+        payload.push_back(v_mptrHeaders);
+
+        auto mptr_gralloc_handle = std::make_shared<struct cros_gralloc_handle>();
+        YAML::convert<CrosGrallocHandlePtr>::decode(createBufferNode["cros_gralloc_handle_t"], mptr_gralloc_handle);
+        std::shared_ptr<void> v_mptrGrallocHandle = mptr_gralloc_handle;
+        payload.push_back(v_mptrGrallocHandle);
+        break;
+    }
+
+    case VHAL_DD_EVENT_REMOVE_BUFFER:
+    case VHAL_DD_EVENT_DISPLAY_ACK:
+    {
+        //These cases all involve a buffer_info_event_t. Can process them all the same
+        auto mptr = std::make_shared<buffer_info_event_t>();
+        YAML::convert<BufferInfoEventPtr>::decode(node["buffer_info_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+        break;
+    }
+
+    case VHAL_DD_EVENT_DISPLAY_REQ:
+    {
+        //This case involves a buffer_info_event_t (Same as above)
+        //And potentially an additional display_control_t
+        auto mptr = std::make_shared<buffer_info_event_t>();
+        YAML::convert<BufferInfoEventPtr>::decode(node["buffer_info_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+
+        int requestSize = mptr->event.size - sizeof(display_event_t);
+        bool hasCtrl = (requestSize == (sizeof(buffer_info_t) + sizeof(display_control_t)));
+        if (hasCtrl)
+        {
+            auto ctrl = std::make_shared<display_control_t>();
+            if (YAML::convert<DisplayCtrlPtr>::decode(node["display_control_t"], ctrl))
+            {
+                v_mptr = ctrl;
+                payload.push_back(v_mptr);
+            }
+        }
+        break;
+    }
+
+    case VHAL_DD_EVENT_DISPPORT_ACK:
+    {
+        auto mptr = std::make_shared<display_port_event_t>();
+        YAML::convert<DisplayPortEventPtr>::decode(node["display_port_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+        break;
+    }
+
+    case VHAL_DD_EVENT_SET_VIDEO_ALPHA_REQ:
+    {
+        auto mptr = std::make_shared<display_set_video_alpha_event_t>();
+        YAML::convert<SetAlphaEventPtr>::decode(node["display_set_video_alpha_event_t"], mptr);
+        std::shared_ptr<void> v_mptr = mptr;
+        payload.push_back(v_mptr);
+        break;
+    }
+
+    default:
+        std::cout << "Unknown event: " << std::to_string(metadata->eventType) << std::endl;
+        return AICS_YML_PARSER_ERR;
+        break;
+    }
+
+    return AICS_ERR_NONE;
+}
+
+
+int CmdHandler::InitYmlParser()
+{
+    try {
+        m_ymlDocs = YAML::LoadAllFromFile(m_ymlFileName);
+    }
+    catch (...) {
+        std::cout << "Exception in Loading  " << m_ymlFileName << std::endl;
+        return AICS_YML_LOAD_ERR;
+    }
+
+    m_nextNode = m_ymlDocs.begin();
+    return AICS_ERR_NONE;
+}
+
+
+int CmdHandler::InitGfxSurfaceHandler()
+{
+    m_inputStream.open(m_inputFileName, std::ios::binary);
+
+    if (! m_inputStream.good())
+        return AICS_ERR_INPUT_STREAM;
+
+    GfxStatus status = GFX_OK;
+    status = m_gfx.GfxInit();
+
+    if (status)
+        return AICS_ERR_GFX;
+
+    return AICS_ERR_NONE;
+}
+
+
+int CmdHandler::GetOneFrame(uint8_t* pFrame, int bytesToRead)
+{
+    if (!m_inputStream.good())
+        return AICS_ERR_INPUT_STREAM;
+
+    if (!pFrame)
+        return AICS_ERR_NULL_PTR;
+
+    if (bytesToRead <= 0)
+        return AICS_ERR_STREAM_PARAMS;
+
+    m_inputStream.read((char *)pFrame, bytesToRead);
+
+    //Loop over if meeting EoF
+    if (m_inputStream.eof())
+    {
+        m_inputStream.clear();
+        m_inputStream.seekg(0, m_inputStream.beg);
+    }
+
+    return AICS_ERR_NONE;
+}

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -1,0 +1,178 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __CMD_HANDLER
+#define __CMD_HANDLER__
+
+#include <stdio.h>
+#include <cstring>
+#include <thread>
+#include <fstream>
+
+#include "display-protocol.h"
+#include "libvhal_common.h"
+#include "yaml-cpp/yaml.h"
+#include "YmlParser.h"
+#include "GfxHandler.h"
+#include "SocketServer.h"
+
+#define DEFAULT_SOCKET_PATH "/ipc"
+#define HWC_UNIX_SOCKET "/hwc-sock"
+
+//Support only 1 File descriptor per create buffer event
+#define MAX_FD_SUPPORTED 1
+
+#define CHECK_STATUS(status)                                                  \
+    if (status != AICS_ERR_NONE) {                                            \
+        std::string errString = "Error " + std::to_string(status) + " at ";   \
+        errString += std::string(__FILE__) + ": "+ std::to_string( __LINE__); \
+        errString += " (" + std::string(__FUNCTION__) + ")";                  \
+        std::cout << errString << std::endl;                                  \
+        return status;                                                        \
+    };
+
+#if (__DEBUG)
+#define AIC_LOG() {                                                     \
+    std::string str = std::string(__FILE__) + ": "+ std::to_string( __LINE__); \
+    str += " (" + std::string(__FUNCTION__) + ")";                      \
+    std::cout << str << std::endl;                                      \
+    };
+#else
+#define AIC_LOG() ;
+#endif
+
+
+using namespace aic_emu::server;
+
+enum AicError_t {
+    AICS_ERR_NONE = 0,
+    AICS_ERR_INVALID_ARGS = 1,
+    AICS_FILE_READ_ERR = 2,
+    AICS_SOCKET_ERROR = 3,
+    AICS_YML_LOAD_ERR = 4,
+    AICS_YML_PARSER_ERR = 5,
+    AICS_ERR_NULL_PTR = 6,
+    AICS_ERR_EOF = 7,
+    AICS_ERR_PAYLOAD_EMPTY = 8,
+    AICS_ERR_BAD_METADATA = 9,
+    AICS_ERR_INPUT_STREAM = 10,
+    AICS_ERR_STREAM_PARAMS = 11,
+    AICS_ERR_SOCKET_INIT = 12,
+    AICS_ERR_SOCKET_CONNECT = 13,
+    AICS_ERR_SOCKET = 14,
+    AICS_ERR_GFX = 15,
+    AICS_ERR_UNKNOWN = 16,
+    AICS_TOTAL_ERRORS
+};
+
+struct AicSocketData_t
+{
+    int session_id; //server session Id
+    int user_id;    //user Id
+    std::string hwc_sock; //socket path
+    int android_instance_id;
+};
+
+
+enum EventDirection_t {
+    DIRECTION_SEND = 0,
+    DIRECTION_RECEIVE = 1,
+    DIRECTION_UNKNOWN = 2
+};
+
+struct AicEventCounters
+{
+    unsigned int CreateBufferEvents;
+    unsigned int RemoveBufferEvents;
+    unsigned int DisplayReqEvents;
+    unsigned int ChangeResolutionEvents;
+    unsigned int DispInfoReqEvents;
+    unsigned int DispPortReqEvents;
+    unsigned int SetAlphaEvents;
+};
+
+
+struct AicEventMetadata_t
+{
+    unsigned int eventId;
+    unsigned int eventType;
+    unsigned direction;
+    unsigned long timeStampUs;
+    AicEventCounters counts;
+};
+
+class CmdHandler
+{
+public:
+    CmdHandler(std::string ymlFile, std::string inputFile, AicSocketData_t* info);
+    ~CmdHandler();
+
+    int Init();
+
+    int ProcessNextEntry();
+
+
+
+private:
+    //Init functions
+    int InitSocket();
+    int InitGfxSurfaceHandler();
+    int InitYmlParser();
+
+    //YML Parsing
+    int DecodeNode(YAML::Node& node, std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
+
+    //INPUT File and Gfx Surface Handling + FPS management
+    int  GetOneFrame(uint8_t* pFrame, int sizeToRead);
+    void ManageDisplayReqTime(AicEventMetadataPtr& metadata);
+
+    //Data to ICR
+    int DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
+    int Xchng_DisplayRequest(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
+
+    //Socket related Functions
+    int WriteIntoSocket(void* data, uint32_t sizeInBytes);
+    int ReadFromSocket(void* dst, uint32_t sizeInBytes);
+    int SendFDs(boData_t* boData);
+
+
+    //Socket related variables
+    UnixConnectionInfo m_UnixConnInfo;
+    std::unique_ptr<UnixServerSocket> m_socket;
+
+    //YML Parser Related variables
+    std::string                       m_ymlFileName;
+    std::vector<YAML::Node>           m_ymlDocs;
+    std::vector<YAML::Node>::iterator m_nextNode;
+
+    //INPUT File and Gfx Surface Handling
+    std::string                       m_inputFileName;
+    std::ifstream                     m_inputStream;
+    GfxHandler                        m_gfx;
+
+    //Struct holding operating surface parameters
+    std::shared_ptr<cros_gralloc_handle> m_props;
+
+    //fps management
+    unsigned long                     m_lastDispReqSentTS;
+    unsigned long                     m_lastDispReqYmlTS;
+    unsigned long                     m_firstDispReqSentTS;
+};
+
+#endif

--- a/aic-emu/GfxHandler.cc
+++ b/aic-emu/GfxHandler.cc
@@ -1,0 +1,555 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <dirent.h>
+
+#include <errno.h>
+
+#include <iostream>
+#include <cstdlib>
+#include <string>
+#include <cstring>
+
+#include "GfxHandler.h"
+
+#define DEFAULT_GFX_DEVICE "/dev/dri/renderD128"
+
+GfxHandler::GfxHandler(const char* deviceStr)
+{
+    if (deviceStr)
+        m_device_str = deviceStr;
+    else
+        m_device_str = DEFAULT_GFX_DEVICE;
+}
+
+GfxHandler::~GfxHandler()
+{
+    for (auto it = m_boList.begin(); it != m_boList.end();)
+    {
+        //De-allocate BO
+        ClearBo(it->first, false);
+
+        //Erase from BO map
+        it = m_boList.erase(it);
+    }
+
+    if (m_device_fd > 0)
+    {
+        GfxStatus status = GFX_OK;
+        status = GfxClose();
+        GFX_LOG_STATUS(status != GFX_OK, "GfxClose");
+    }
+}
+
+GfxStatus GfxHandler::RunIoctl(unsigned long request, void* buf)
+{
+   int sts = GFX_OK;
+
+   if (!buf)
+   {
+       std::cout <<std::string(__FUNCTION__) << ": Non-null pointer required for buf" << std::endl;
+       return GFX_FAIL;
+   }
+
+   do
+   {
+     sts = ioctl(m_device_fd, request, buf);
+   }
+   while (sts == -1 && (errno == EINTR || errno == EAGAIN));
+
+   std::string errorString = std::string(__FUNCTION__) + ": Req " + std::to_string(request);
+   GFX_LOG_FAILURE(sts != 0, errorString.c_str());
+
+   return (GfxStatus) sts;
+}
+
+GfxStatus GfxHandler::GetDrmParam(unsigned long request, int* val)
+{
+   if (!val)
+   {
+       std::cout <<std::string(__FUNCTION__) << ": Non-null pointer required for val" << std::endl;
+       return GFX_FAIL;
+   }
+
+   struct drm_i915_getparam gp = { .param = (int)request, .value = val };
+
+   return RunIoctl(DRM_IOCTL_I915_GETPARAM, &gp);
+}
+
+GfxStatus GfxHandler::GfxInit()
+{
+    int sts = GFX_OK;
+    int mmap_gtt_version = -1;
+
+    if(m_device_str.empty())
+    {
+        std::cout << "Error: Empty device string in Init" << std::endl;
+        sts = GFX_FAIL;
+        goto exit_logic;
+    }
+    else
+        std::cout << "Using device " << m_device_str << std::endl;
+
+    //Init device props to 0
+    m_device_props = {.chipsetId = 0, .hasMMAPoffset = 0};
+
+    //Open device
+    m_device_fd = open(m_device_str.c_str(), O_RDWR);
+    GFX_LOG_STATUS((m_device_fd < 0), "open device");
+    if (!GFX_SUCCESS(m_device_fd < 0))
+        goto exit_logic;
+
+    //Get version info
+    struct drm_version drm_ver;
+    memset(&drm_ver, 0, sizeof(drm_ver));
+
+    sts = RunIoctl(DRM_IOCTL_VERSION, &drm_ver);
+
+    GFX_LOG_FAILURE(sts != GFX_OK, "drmIoctl DRM_IOCTL_VERSION first");
+    if (!GFX_SUCCESS(sts))
+        goto exit_logic;
+
+    //Allocate memory and call the ioctl again to actually get the name
+    if (drm_ver.name_len > 0)
+    {
+        drm_ver.name = (char *)malloc(drm_ver.name_len + 1);
+
+        sts = RunIoctl(DRM_IOCTL_VERSION, &drm_ver);
+
+        GFX_LOG_FAILURE(sts != GFX_OK, "drmIoctl DRM_IOCTL_VERSION second");
+
+        if (drm_ver.name_len >=0)
+            drm_ver.name[drm_ver.name_len] = '\0';
+
+        m_device_props.version = (const char *) drm_ver.name;
+
+        if (drm_ver.name)
+            free(drm_ver.name);
+
+        if (!GFX_SUCCESS(sts))
+            goto exit_logic;
+    }
+
+    //Get Chipset ID
+    sts = GetDrmParam(I915_PARAM_CHIPSET_ID, &m_device_props.chipsetId);
+    GFX_LOG_FAILURE(sts != 0, "drmIoctl I915_PARAM_CHIPSET_ID");
+    if (!GFX_SUCCESS(sts))
+        goto exit_logic;
+
+
+    //MMAP offset
+    sts = GetDrmParam(I915_PARAM_MMAP_GTT_VERSION, &mmap_gtt_version);
+    if (!GFX_SUCCESS(sts))
+        goto exit_logic;
+    m_device_props.hasMMAPoffset = (mmap_gtt_version >= 4);
+
+    if (!m_device_props.hasMMAPoffset)
+    {
+        std::cout << "Error: Device doesn't have MMAPoffset function." << std::endl;
+        sts = GFX_FAIL;
+    }
+
+exit_logic:
+    if (!GFX_SUCCESS(sts))
+    {
+        if (m_device_fd >= 0)
+        {
+            close(m_device_fd);
+            m_device_fd = -1;
+        }
+    }
+
+    std::cout << std::string(__FUNCTION__) << ": drmVersion.name = " << m_device_props.version << "\n"
+              << "\tchipsetID = 0x" << std::hex  << m_device_props.chipsetId << std::dec << "\n"
+              << "\thasMMAPoffset = " << m_device_props.hasMMAPoffset << std::endl;
+
+    return (GfxStatus)sts;
+}
+
+GfxStatus GfxHandler::GfxClose()
+{
+    GfxStatus sts = GFX_OK;
+
+    if (m_device_fd >= 0)
+    {
+        close(m_device_fd);
+        m_device_fd = -1;
+    }
+    return sts;
+}
+
+GfxStatus GfxHandler::DetermineSurfaceParams(SurfaceParams_t& surf, unsigned width, unsigned height, unsigned format)
+{
+    if (width == 0 || height == 0 || format == 0)
+    {
+        std::cout << "Error: Unexpected surface parameter: width = " << width
+                  << ", height = " << height << ", format = " << format << std::endl;
+
+        return GFX_FAIL;
+    }
+
+	uint32_t horizontal_alignment = 4;
+	uint32_t vertical_alignment = 4;
+
+    memset(&surf, 0, sizeof(SurfaceParams_t));
+
+    surf.width  = width;
+    surf.height = height;
+    surf.format = format;
+    surf.pitch  = surf.width;
+
+    surf.tilingFormat = GetTilingFormat(format);
+
+    switch (surf.tilingFormat)
+    {
+    default:
+    case I915_TILING_NONE:
+        horizontal_alignment = 64;
+        break;
+
+    case I915_TILING_X:
+        horizontal_alignment = 512;
+        vertical_alignment = 8;
+        break;
+
+    case I915_TILING_Y:
+        horizontal_alignment = 128;
+        vertical_alignment = 32;
+        break;
+    }
+
+    /*
+	 * The alignment calculated above is based on the full size luma plane and to have chroma
+	 * planes properly aligned with subsampled formats, we need to multiply luma alignment by
+	 * subsampling factor.
+	 */
+	switch (surf.format)
+    {
+	case DRM_FORMAT_YVU420_ANDROID:
+	case DRM_FORMAT_YVU420:
+		horizontal_alignment *= 2;
+
+	case DRM_FORMAT_NV12:
+		vertical_alignment *= 2;
+		break;
+
+    case DRM_FORMAT_NV12_Y_TILED_INTEL:
+        vertical_alignment = 64;
+        break;
+
+    default:
+        break;
+	}
+
+	surf.alignedHeight = ALIGN(surf.height, vertical_alignment);
+
+    surf.alignedWidth = ALIGN(surf.width, horizontal_alignment);
+
+    surf.pitch = surf.alignedWidth;
+
+    surf.pixelSize = GetPixelSize(surf.format);
+
+    surf.totalSize = surf.alignedWidth * surf.alignedHeight * surf.pixelSize;
+
+    /*
+	 * Quoting Mesa ISL library:
+	 *
+	 *    - For linear surfaces, additional padding of 64 bytes is required at
+	 *      the bottom of the surface. This is in addition to the padding
+	 *      required above.
+	 */
+	if (surf.tilingFormat == I915_TILING_NONE)
+		surf.totalSize += 64;
+
+	return GFX_OK;
+}
+
+unsigned GfxHandler::GetTilingFormat(unsigned int format)
+{
+    //Currently only linear format is supported.
+    return I915_TILING_NONE;
+}
+
+size_t GfxHandler::GetPixelSize(unsigned int format)
+{
+    //Currently only 4-byte packed format is supported.
+    return 4;
+}
+
+GfxStatus GfxHandler::AllocateBo(SurfaceParams_t& surf, uint64_t remote_handle)
+{
+    int sts = GFX_OK;
+
+    std::string errString;
+
+    if (surf.tilingFormat != I915_TILING_NONE)
+    {
+        std::cout << "Error: Unsupported Tiling format: " << surf.tilingFormat << std::endl;
+        return GFX_FAIL;
+    }
+
+#if (__DEBUG)
+    printf("surf = {w = %d, h = %d, p = %d, f = %d,\n", surf.width, surf.height, surf.pitch, surf.format);
+    printf("surf = {tf = %d, aH = %d, aW = %d,\n", surf.tilingFormat, surf.alignedHeight, surf.alignedWidth);
+    printf("surf = {pixelSize = %d, totalSize = %d\n", surf.pixelSize, surf.totalSize);
+#endif
+
+    // -- Ioctl to create surface
+    struct drm_i915_gem_create gem_create;
+    memset(&gem_create, 0, sizeof(gem_create));
+    gem_create.size = surf.totalSize;
+
+    sts = RunIoctl(DRM_IOCTL_I915_GEM_CREATE, &gem_create);
+
+    errString = "Ioctl I915_GEM_CREATE: size = " + std::to_string(gem_create.size);
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+
+    // -- Get FD
+    struct drm_prime_handle gem_handle_fd;
+    memset(&gem_handle_fd, 0, sizeof(gem_handle_fd));
+
+    gem_handle_fd.fd     = -1;
+    gem_handle_fd.handle = gem_create.handle;
+    gem_handle_fd.flags  = DRM_CLOEXEC | DRM_RDWR;
+
+    sts = RunIoctl(DRM_IOCTL_PRIME_HANDLE_TO_FD, &gem_handle_fd);
+
+    errString = "Ioctl PRIME_HANDLE_TO_FD: handle = " + std::to_string(gem_handle_fd.handle);
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    // -- Insert into vector, referencing with remote handle specified in the YML log
+    boData_t boData = {.surf      = surf,
+                       .fd        = gem_handle_fd.fd,
+                       .handle    = gem_create.handle,
+                       .mmap_addr = nullptr};
+
+    m_boList.insert(std::make_pair(remote_handle, boData));
+
+#if (__DEBUG)
+    printf("%s: remote_handle = %lu .. prime_fd = %d .. real_handle = %lu\n",
+           __FUNCTION__, remote_handle, boData.fd, boData.handle);
+#endif
+
+    return GFX_OK;
+}
+
+GfxStatus GfxHandler::ClearBo(uint64_t remote_handle, bool erase)
+{
+    GfxStatus sts = GFX_OK;
+    std::string errString;
+
+    auto bo_entry = m_boList.find(remote_handle);
+    if (bo_entry == m_boList.end())
+    {
+        std::cout << "Could not find bo with remote_handle= " << remote_handle << std::endl;
+        return GFX_FAIL;
+    }
+
+    struct drm_gem_close gem_close;
+    memset(&gem_close, 0, sizeof(gem_close));
+    gem_close.handle = bo_entry->second.handle;
+
+    sts = RunIoctl(DRM_IOCTL_GEM_CLOSE, &gem_close);
+
+    errString = "Ioctl GEM_CLOSE: handle = " + std::to_string(gem_close.handle);
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    //Remove record from map, if enabled
+    if (erase)
+        m_boList.erase(bo_entry);
+
+    return GFX_OK;
+}
+
+boData_t* GfxHandler::GetBo(uint64_t handle)
+{
+    if (m_boList.size() == 0)
+        return nullptr;
+
+    auto bo_entry = m_boList.find(handle);
+    if (bo_entry == m_boList.end())
+    {
+        std::cout << "Could not find bo with handle= " << handle << std::endl;
+        return nullptr;
+    }
+
+    return &bo_entry->second;
+}
+
+GfxStatus GfxHandler::Copy(boData_t* dstData, const void* srcBuf)
+{
+    if (!srcBuf || !dstData)
+    {
+        std::cout << "Error: Unexpected Null Ptr: srcBuf = 0x"<< std::hex << srcBuf
+                  << " , dstData = 0x" << std::hex << dstData << std::dec << std::endl;
+        return GFX_FAIL;
+    }
+
+    GfxStatus sts = GFX_OK;
+    std::string errString;
+
+    SurfaceParams_t surf = dstData->surf;
+    size_t sizeDstPerRow = surf.pitch * surf.pixelSize;
+    size_t sizeSrcPerRow = surf.width * surf.pixelSize;
+
+    //Map buffer for CPU write
+    sts = MmapBo(dstData, true);
+
+    errString = "MmapBo call: ";
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    uint8_t* dst = (uint8_t*) dstData->mmap_addr;
+    uint8_t* src = (uint8_t*) srcBuf;
+    for (unsigned i = 0; i < surf.height; i++)
+    {
+        memcpy(dst, src, sizeDstPerRow);
+        dst += sizeDstPerRow;
+        src += sizeSrcPerRow;
+    }
+
+    //Unmap and return
+    return UnmapBo(dstData);
+}
+
+int GfxHandler::GetMmapType(boData_t* bo_gem)
+{
+    // Options:
+    // - I915_MMAP_OFFSET_WC (Write combine)
+    // - I915_MMAP_OFFSET_WC (Write combine)
+
+    //Support only Write Combine now
+    return I915_MMAP_OFFSET_WC;
+}
+
+GfxStatus GfxHandler::MmapBo(boData_t* bo_gem, bool writeEnable)
+{
+    int sts = 0;
+    std::string errString;
+
+    if (m_device_props.hasMMAPoffset == 0)
+    {
+        std::cout << "Error: mmap relies on offset mechanism" << std::endl;
+        return GFX_FAIL;
+    }
+
+    // Run GEM_MMAP_OFFSET Ioctl to set up
+    struct drm_i915_gem_mmap_offset mmap_offset_arg;
+    memset(&mmap_offset_arg, 0, sizeof(mmap_offset_arg));
+
+    mmap_offset_arg.handle = bo_gem->handle;
+    mmap_offset_arg.flags = GetMmapType();
+
+    sts = RunIoctl(DRM_IOCTL_I915_GEM_MMAP_OFFSET, &mmap_offset_arg);
+
+    errString = "Ioctl I915_GEM_MMAP_OFFSET";
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    // Issue the mmap system call
+    bo_gem->mmap_addr = mmap(NULL,
+                             bo_gem->surf.totalSize,
+                             PROT_READ | PROT_WRITE,
+                             MAP_SHARED,
+                             m_device_fd,
+                             mmap_offset_arg.offset);
+
+    if (bo_gem->mmap_addr == MAP_FAILED)
+    {
+        bo_gem->mmap_addr = nullptr;
+
+        errString = "Ioctl I915_GEM_MMAP_OFFSET";
+        GFX_LOG_FAILURE(sts != 0, errString.c_str());
+        if (!GFX_SUCCESS(sts))
+            return GFX_FAIL;
+    }
+
+    // Specify domain
+
+    struct drm_i915_gem_set_domain set_domain;
+    memset(&set_domain, 0, sizeof(set_domain));
+
+    set_domain.handle = bo_gem->handle;
+    set_domain.read_domains = I915_GEM_DOMAIN_CPU;
+    if (writeEnable)
+        set_domain.write_domain = I915_GEM_DOMAIN_CPU;
+    else
+        set_domain.write_domain = 0;
+
+    sts = RunIoctl(DRM_IOCTL_I915_GEM_SET_DOMAIN, &set_domain);
+
+    errString = "Ioctl I915_GEM_SET_DOMAIN";
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    return GFX_OK;
+}
+
+
+GfxStatus GfxHandler::UnmapBo(boData_t* bo_gem)
+{
+    int sts;
+    std::string errString;
+
+    if (bo_gem == nullptr)
+    {
+        std::cout << "Error: bo cannot be null to unmap" << std::endl;
+        return GFX_FAIL;
+    }
+
+    if (bo_gem->mmap_addr == nullptr)
+    {
+        std::cout << "Warning: mmap_addr is null. Nothing to unmap" << std::endl;
+        return GFX_OK;
+    }
+
+    struct drm_i915_gem_sw_finish sw_finish;
+    memset(&sw_finish, 0, sizeof(sw_finish));
+
+    sw_finish.handle = bo_gem->handle;
+
+    sts = RunIoctl(DRM_IOCTL_I915_GEM_SW_FINISH, &sw_finish);
+
+    errString = "Ioctl I915_GEM_SW_FINISH";
+    GFX_LOG_FAILURE(sts != 0, errString.c_str());
+    if (!GFX_SUCCESS(sts))
+        return GFX_FAIL;
+
+    bo_gem->mmap_addr = nullptr;
+
+    return GFX_OK;
+}

--- a/aic-emu/GfxHandler.h
+++ b/aic-emu/GfxHandler.h
@@ -1,0 +1,150 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __GFX_HANDLER_H__
+#define __GFX_HANDLER_H__
+
+#include <sys/ioctl.h>
+#include <drm/i915_drm.h>
+#include <drm/drm_fourcc.h>
+
+#include <map>
+
+#define GFX_SUCCESS(_res) \
+    (GFX_OK == (_res))
+
+#define GFX_LOG_STATUS(_failed, _msg)   \
+    GFX_LOG(_failed, _msg, true);
+
+#define GFX_LOG_FAILURE(_failed, _msg)  \
+    GFX_LOG(_failed, _msg, _failed);
+
+#define GFX_LOG(failed, msg, condition) do {                                                          \
+    std::string printMsg(msg);                                                                        \
+    printMsg += ((failed) ? " failed " : " succeeded");                                               \
+    if (condition) {                                                                                  \
+        printMsg += ":(" + std::string(__FILE__) +  ":line " + std::to_string(__LINE__) + ")";        \
+        std::cout << printMsg << std::endl;                                                           \
+        if ((failed))                                                                                 \
+            std::cout <<"\tError " << errno << ":" << strerror(errno) <<" (" << __FUNCTION__ <<")\n"; \
+    }                                                                                                 \
+} while(0);                                                                                           \
+
+#define CHECK_ERRNO_STATUS(status)                                      \
+    if ((status) != 0) {                                                \
+        printf("Encountered error in %s (line %d) : Error %d (%s)\n", __FUNCTION__, __LINE__, errno, strerror(errno)); \
+    }
+
+#define ALIGN(X, N) (N)*(((X) + (N) - 1)/(N))
+
+enum GfxStatus
+{
+    GFX_OK = 0,
+    GFX_FAIL = -1
+};
+
+enum surf_format
+{
+    DRM_FORMAT_LINEAR             = 0,
+    DRM_FORMAT_YVU420_ANDROID     = 1,
+    DRM_FORMAT_NV12_Y_TILED_INTEL = 2
+};
+
+struct SurfaceParams_t
+{
+    // --- Sent to ICR and used
+    unsigned int width;
+    unsigned int height;
+    unsigned int pitch;
+    unsigned int format;
+
+    // --- Not used by ICR, but sent to it
+    unsigned int tilingFormat;
+    unsigned int alignedHeight;
+    unsigned int alignedWidth;
+
+    // --- For internal usage
+    unsigned int pixelSize;
+    unsigned int totalSize;
+};
+
+struct boData_t
+{
+    // Parameters of a bo / surface
+    SurfaceParams_t surf;
+
+    // DRM Prime File descriptor corresponding to allocated surface
+    // Passed to ICR along with a remote handle from the YML log (generated in AIC allocation)
+    int             fd;
+
+    // Real handle capturing the surface allocation in this emulator app. This is NOT sent to ICR
+    // The remote handle is simply used to lookup the corresponding prime FD.
+    // This is served by the handle listed in the YML log dumped by AIC, so we just send that instead.
+    unsigned int    handle;
+
+    // Memory mapping address
+    void*           mmap_addr;
+};
+
+struct GfxDeviceProps_t
+{
+    std::string   version;
+    int           chipsetId;
+    int           hasMMAPoffset;
+};
+
+class GfxHandler
+{
+public:
+
+    GfxHandler(const char* deviceStr = nullptr);
+    ~GfxHandler();
+
+    GfxStatus GfxInit();
+    GfxStatus GfxClose();
+    GfxStatus AllocateBo(SurfaceParams_t& surf, uint64_t handle);
+    GfxStatus ClearBo(uint64_t handle, bool erase = true);
+    GfxStatus Copy(boData_t* dstData, const void* srcBuf);
+
+    GfxStatus DetermineSurfaceParams(SurfaceParams_t& surf, unsigned width,
+                                      unsigned height, unsigned format);
+    boData_t*  GetBo(uint64_t handle);
+
+protected:
+
+    //Internal functions interfacing with Kernel
+    GfxStatus GetDrmParam(unsigned long request, int* outPtr);
+    GfxStatus RunIoctl(unsigned long request, void* buf);
+
+    GfxStatus MmapBo(boData_t* bo_gem, bool writeEnable);
+    GfxStatus UnmapBo(boData_t* bo_gem);
+
+    //Other internal helper functions
+    int        GetMmapType(boData_t* bo_gem = nullptr);
+    size_t     GetPixelSize(unsigned int format);
+    unsigned   GetTilingFormat(unsigned int format);
+
+    // State variables
+    std::string                  m_device_str;
+    int                          m_device_fd;
+    GfxDeviceProps_t             m_device_props;
+    std::map<uint64_t, boData_t> m_boList;
+};
+#endif
+

--- a/aic-emu/SocketServer.cc
+++ b/aic-emu/SocketServer.cc
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "SocketServer.h"
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <system_error>
+
+namespace aic_emu {
+namespace server {
+
+    UnixServerSocket::UnixServerSocket(const std::string& server_socket_path)
+    {
+        connected_ = false;
+        server_.sun_family = AF_UNIX;
+        strncpy(server_.sun_path, server_socket_path.c_str(), sizeof(server_.sun_path) -1);
+        server_socket_path_ = server_socket_path;
+    }
+
+    UnixServerSocket::~UnixServerSocket()
+    {
+        Close();
+    }
+
+    bool UnixServerSocket::AwaitConnection()
+    {
+        int status = 0;
+        if (server_fd_ >= 0 || fd_ >= 0)
+            Close();
+
+        //Create Server Socket to accept connections
+        server_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+        if (server_fd_ < 0)
+        {
+            std::cout << "Socket create Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+            throw std::system_error(errno, std::system_category());
+        }
+
+        //Unlink existing files. Else will run into bind errors
+        status = unlink(server_socket_path_.c_str());
+        if (status !=  0)
+            std::cout << "Unlink Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+
+        //Bind
+        status = bind(server_fd_, (struct sockaddr*)&server_, SUN_LEN(&server_));
+        if (status < 0)
+        {
+            std::cout << "Bind Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+            throw std::system_error(errno, std::system_category());
+        }
+
+        //Make socket writable and accessible to all users
+        status = chmod(server_socket_path_.c_str(),
+                       S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IWGRP|S_IXGRP|S_IROTH|S_IWOTH|S_IXOTH);
+        if(status < 0)
+        {
+            std::cout << "Socket chmod Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+            throw std::system_error(errno, std::system_category());
+        }
+
+        //Configure Listen
+        status = listen(server_fd_, MAX_CONNECTIONS);
+        if (status < 0)
+        {
+            std::cout << "Listen Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+            throw std::system_error(errno, std::system_category());
+        }
+
+        //Block for client connection
+        std::cout << "Awaiting Client connection: Path: " << std::string(server_.sun_path) << std::endl;
+        fd_ = accept(server_fd_, NULL, NULL);
+        if (fd_ < 0)
+        {
+            std::cout << "Accept Failed. Error " << errno << ": " << std::strerror(errno) << std::endl;
+            throw std::system_error(errno, std::system_category());
+        }
+
+        connected_ = true;
+
+        return connected_;
+    }
+
+    bool UnixServerSocket::Connected() { return connected_; }
+
+    IOResult UnixServerSocket::Send(const uint8_t* data, size_t size)
+    {
+        std::string error_msg = "";
+
+        ssize_t sent;
+        if ((sent = ::send(fd_, data, size, 0)) == -1) {
+            std::cout << ". Send() args: fd: " << fd_ << ", data: " << data
+                      << ", size: " << size << "\n";
+            error_msg = std::strerror(errno);
+        }
+        return { sent, error_msg };
+    }
+
+    IOResult UnixServerSocket::Recv(uint8_t* data, size_t size)
+    {
+        std::string error_msg = "";
+
+        ssize_t received;
+        if ((received = ::recv(fd_, data, size, 0)) == -1) {
+            std::cout << ". Recv() args: fd: " << fd_ << ", data: " << data
+                      << ", size: " << size << "\n";
+            error_msg = std::strerror(errno);
+        }
+        return { received, error_msg };
+    }
+
+    IOResult UnixServerSocket::SendMsg(int* data, size_t sizeInBytes)
+    {
+        std::string error_msg = "";
+        if (!data) {
+            error_msg =  std::string("Null Pointer for data");
+            return { -1, error_msg };
+        }
+
+        if (sizeInBytes <= 0) {
+            error_msg = std::string("Invalid size specified: ") + std::to_string(sizeInBytes);
+            return { -1, error_msg };
+        }
+
+        //Prepare message
+        int sdata[4] = {0x88};
+
+        struct msghdr msg = {0};
+        struct cmsghdr *cmsg = nullptr;
+        struct iovec vec;
+
+        char buf[CMSG_SPACE(sizeInBytes)]; //ancillary data buffer
+
+        msg.msg_control = buf;
+        msg.msg_controllen = sizeof(buf);
+        cmsg = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_level = SOL_SOCKET;
+        cmsg->cmsg_type = SCM_RIGHTS;
+        cmsg->cmsg_len = CMSG_LEN(sizeInBytes);
+
+        // Init payload
+        int* payload  = (int *) CMSG_DATA(cmsg);
+        memcpy(payload, data, sizeInBytes);
+
+        // Program msg
+        msg.msg_name = NULL;
+        msg.msg_namelen = 0;
+        msg.msg_iov = &vec;
+        msg.msg_iovlen = 1;
+        msg.msg_flags = 0;
+
+        vec.iov_base = &sdata;
+        vec.iov_len = 16;
+
+        ssize_t sent;
+        if ((sent = ::sendmsg(fd_, &msg, MSG_NOSIGNAL)) < 0)
+        {
+            std::cout << ". sendmsg() args: fd: " << fd_ << ", data: " << data
+                      << ", sizeInBytes: " << sizeInBytes << std::endl;
+            std::cout << ". msg. msg_controllen: " << msg.msg_controllen << std::endl;
+            error_msg = std::strerror(errno);
+        }
+
+        std::cout << std::string(__FUNCTION__) << ": Sent "<< sent << " bytes ... "
+                  << "payload fd: " << *data << std::endl;
+        return { sent, error_msg };
+    }
+
+
+    void UnixServerSocket::Close()
+    {
+        connected_ = false;
+        if (fd_ >= 0)
+        {
+            shutdown(fd_, SHUT_RDWR);
+            close(fd_);
+            fd_ = -1;
+        }
+        if (server_fd_ >= 0)
+        {
+            shutdown(server_fd_, SHUT_RDWR);
+            close(server_fd_);
+            server_fd_ = -1;
+        }
+    }
+
+} // namespace server
+} // namespace vhal
+

--- a/aic-emu/SocketServer.h
+++ b/aic-emu/SocketServer.h
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef UNIX_STREAM_SOCKET_SERVER_H
+#define UNIX_STREAM_SOCKET_SERVER_H
+
+#include <iostream>
+#include <memory>
+#include <string>
+extern "C"
+{
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/stat.h>
+#include <unistd.h>
+}
+
+using IOResult = std::tuple<ssize_t, std::string>;
+
+#define MAX_CONNECTIONS 1
+
+namespace aic_emu {
+namespace server {
+
+class UnixServerSocket
+{
+public:
+    UnixServerSocket(const std::string& server_path);
+    ~UnixServerSocket();
+
+    bool             AwaitConnection();
+    bool             Connected();
+    IOResult         Send(const uint8_t* data, size_t size);
+    IOResult         Recv(uint8_t* data, size_t size);
+    IOResult         SendMsg(int* data, size_t sizeInBytes);
+    void             Close() ;
+
+private:
+    int  fd_ = -1;
+    int  server_fd_ = -1;
+    bool connected_ = false;
+
+    struct sockaddr_un server_;
+    std::string        server_socket_path_;
+};
+} // namespace server
+} // namespace aic_emu
+
+#endif /* UNIX_STREAM_SOCKET_CLIENT_H */

--- a/aic-emu/YmlParser.cc
+++ b/aic-emu/YmlParser.cc
@@ -1,0 +1,341 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "CmdHandler.h"
+
+int GetEventCode(std::string str)
+{
+    std::cout << str << "@@@@@@@@@" << std::endl;
+    int event = 0;
+
+    if (str == "VHAL_DD_EVENT_DISPINFO_REQ")
+        return VHAL_DD_EVENT_DISPINFO_REQ;
+    else if (str == "VHAL_DD_EVENT_DISPINFO_ACK")
+        return VHAL_DD_EVENT_DISPINFO_ACK;
+    else if (str == "VHAL_DD_EVENT_CREATE_BUFFER")
+        return VHAL_DD_EVENT_CREATE_BUFFER;
+    else if (str == "VHAL_DD_EVENT_REMOVE_BUFFER")
+        return VHAL_DD_EVENT_REMOVE_BUFFER;
+    else if (str == "VHAL_DD_EVENT_DISPLAY_REQ")
+        return VHAL_DD_EVENT_DISPLAY_REQ;
+    else if (str == "VHAL_DD_EVENT_DISPLAY_ACK")
+        return VHAL_DD_EVENT_DISPLAY_ACK;
+    else if (str == "VHAL_DD_EVENT_SERVER_IP_REQ")
+        return VHAL_DD_EVENT_SERVER_IP_REQ;
+    else if (str == "VHAL_DD_EVENT_SERVER_IP_ACK")
+        return VHAL_DD_EVENT_SERVER_IP_ACK;
+    else if (str == "VHAL_DD_EVENT_SERVER_IP_SET")
+        return VHAL_DD_EVENT_SERVER_IP_SET;
+    else if (str == "VHAL_DD_EVENT_DISPPORT_REQ")
+        return VHAL_DD_EVENT_DISPPORT_REQ;
+    else if (str == "VHAL_DD_EVENT_DISPPORT_ACK")
+        return VHAL_DD_EVENT_DISPPORT_ACK;
+    else if (str == "VHAL_DD_EVENT_SETUP_RESOLUTION")
+        return VHAL_DD_EVENT_SETUP_RESOLUTION;
+
+    return event;
+}
+
+bool YAML::convert<AicEventMetadataPtr>::decode(const YAML::Node& node, AicEventMetadataPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (node["eventId"] && node["eventId"].IsScalar()) {
+        mptr->eventId = node["eventId"].as<unsigned int>();
+    }
+
+    if (node["eventName"] && node["eventName"].IsScalar()) {
+        std::string eventTypeString = node["eventName"].as<std::string>();
+        mptr->eventType = GetEventCode(eventTypeString);
+    }
+
+    if (node["direction"] && node["direction"].IsScalar()) {
+        std::string directionString = node["direction"].as<std::string>();
+        if (directionString == "send")
+            mptr->direction = DIRECTION_RECEIVE; //Yaml file specifies this from pov of ICR. Flip for AIC pov
+        else if (directionString == "receive")
+            mptr->direction = DIRECTION_SEND; //Yaml file specifies this from pov of ICR. Flip for AIC pov
+        else
+            mptr->direction = DIRECTION_UNKNOWN;
+    }
+
+    if (node["timeStampUs"] && node["timeStampUs"].IsScalar()) {
+        mptr->timeStampUs = node["timeStampUs"].as<unsigned long>();
+    }
+
+    if (node["counts"] && node["counts"].IsMap()) {
+        YAML::Node counts = node["counts"];
+        mptr->counts.CreateBufferEvents = counts["CreateBufferEvents"].as<unsigned int>();
+        mptr->counts.RemoveBufferEvents = counts["RemoveBufferEvents"].as<unsigned int>();
+        mptr->counts.DisplayReqEvents = counts["DisplayReqEvents"].as<unsigned int>();
+        mptr->counts.ChangeResolutionEvents = counts["ChangeResolutionEvents"].as<unsigned int>();
+        mptr->counts.DispInfoReqEvents = counts["DispInfoReqEvents"].as<unsigned int>();
+        mptr->counts.DispPortReqEvents = counts["DispPortReqEvents"].as<unsigned int>();
+        mptr->counts.SetAlphaEvents    = counts["SetAlphaEvents"].as<unsigned int>();
+    }
+
+    return true;
+}
+
+bool YAML::convert<DisplayEventPtr>::decode(const YAML::Node& node, DisplayEventPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    mptr->type = node["type"].as<unsigned int>();
+    mptr->size = node["size"].as<unsigned int>();
+    mptr->id   = node["id"].as<unsigned int>();
+    mptr->renderNode = node["renderNode"].as<unsigned int>();
+
+    return true;
+}
+
+bool YAML::convert<DisplayInfoPtr>::decode(const YAML::Node& node, DisplayInfoPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    mptr->flags  = node["flags"].as<unsigned int>();
+    mptr->width  = node["width"].as<unsigned int>();
+    mptr->height = node["height"].as<unsigned int>();
+    mptr->stride = node["stride"].as<int>();
+    mptr->format = node["format"].as<int>();
+    mptr->xdpi   = node["xdpi"].as<float>();
+    mptr->ydpi   = node["ydpi"].as<float>();
+    mptr->fps    = node["fps"].as<float>();
+    mptr->minSwapInterval = node["minSwapInterval"].as<int>();
+    mptr->maxSwapInterval = node["maxSwapInterval"].as<int>();
+    mptr->numFramebuffers = node["numFramebuffers"].as<int>();
+
+    return true;
+}
+
+bool YAML::convert<DisplayPortPtr>::decode(const YAML::Node& node, DisplayPortPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    mptr->port = node["port"].as<unsigned int>();
+    mptr->reserve = node["reserve"].as<unsigned int>();
+    return true;
+}
+
+bool YAML::convert<BufferInfoPtr>::decode(const YAML::Node& node, BufferInfoPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    mptr->remote_handle = node["remote_handle"].as<unsigned long>();
+    return true;
+}
+
+template <typename T> bool GetSequence(const YAML::Node node, T* dst)
+{
+    if (dst == nullptr)
+        return false;
+
+    if (node.IsSequence())
+    {
+        for (unsigned int i = 0; i < node.size(); i++) {
+            dst[i] = node[i].as<T>();
+        }
+    }
+    else
+        return false;
+
+    return true;
+}
+
+bool YAML::convert<CrosGrallocHandlePtr>::decode(const YAML::Node& node, CrosGrallocHandlePtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (node["native_handle_t"] && node["native_handle_t"].IsMap()) {
+        YAML::Node nhNode = node["native_handle_t"];
+        mptr->base.version = nhNode["version"].as<int>();
+        mptr->base.numFds  = nhNode["numFds"].as<int>();
+        mptr->base.numInts = nhNode["numInts"].as<int>();
+    }
+    else
+        return false;
+
+
+    GetSequence<int>(node["fds"], mptr->fds);
+
+    GetSequence<unsigned int>(node["strides"], mptr->strides);
+
+    GetSequence<unsigned int>(node["offsets"], mptr->offsets);
+
+    GetSequence<unsigned int>(node["sizes"], mptr->sizes);
+
+    GetSequence<unsigned int>(node["format_modifiers"], mptr->format_modifiers);
+
+    mptr->width       = node["width"].as<unsigned int>();
+    mptr->height      = node["height"].as<unsigned int>();
+    mptr->format      = node["format"].as<unsigned int>();
+    mptr->tiling_mode = node["tiling_mode"].as<unsigned int>();
+
+    GetSequence<unsigned int>(node["use_flags"], mptr->use_flags);
+
+    mptr->magic        = node["magic"].as<unsigned int>();
+    mptr->pixel_stride = node["pixel_stride"].as<unsigned int>();
+    mptr->droid_format = node["droid_format"].as<int>();
+    mptr->usage        = node["usage"].as<int>();
+    mptr->consumer_usage = node["consumer_usage"].as<unsigned int>();
+    mptr->producer_usage = node["producer_usage"].as<unsigned int>();
+    mptr->yuv_color_range= node["yuv_color_range"].as<unsigned int>();
+
+    mptr->is_updated = node["is_updated"].as<unsigned int>();
+    mptr->is_encoded = node["is_encoded"].as<unsigned int>();
+    mptr->is_encrypted = node["is_encrypted"].as<unsigned int>();
+    mptr->is_key_frame = node["is_key_frame"].as<unsigned int>();
+    mptr->is_interlaced = node["is_interlaced"].as<unsigned int>();
+    mptr->is_mmc_capable = node["is_mmc_capable"].as<unsigned int>();
+
+    mptr->compression_mode = node["compression_mode"].as<unsigned int>();
+    mptr->compression_hint = node["compression_hint"].as<unsigned int>();
+    mptr->codec            = node["codec"].as<unsigned int>();
+    mptr->aligned_width    = node["aligned_width"].as<unsigned int>();
+    mptr->aligned_height   = node["aligned_height"].as<unsigned int>();
+
+    return true;
+}
+
+bool YAML::convert<DisplayInfoEventPtr>::decode(const YAML::Node& node, DisplayInfoEventPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (! (node["display_event_t"] && node["display_event_t"].IsMap()))
+        return false;
+
+    if (! (node["display_info_t"] && node["display_info_t"].IsMap()))
+        return false;
+
+    auto eventPtr = std::make_shared<display_event_t>();
+    YAML::convert<DisplayEventPtr>::decode(node["display_event_t"], eventPtr);
+    mptr->event = *eventPtr;
+
+    auto infoPtr = std::make_shared<display_info_t>();
+    YAML::convert<DisplayInfoPtr>::decode(node["display_info_t"], infoPtr);
+    mptr->info= *infoPtr;
+
+    return true;
+}
+
+bool YAML::convert<DisplayPortEventPtr>::decode(const YAML::Node& node, DisplayPortEventPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (! (node["display_event_t"] && node["display_event_t"].IsMap()))
+        return false;
+
+    if (! (node["display_port_t"] && node["display_port_t"].IsMap()))
+        return false;
+
+    auto eventPtr = std::make_shared<display_event_t>();
+    YAML::convert<DisplayEventPtr>::decode(node["display_event_t"], eventPtr);
+    mptr->event = *eventPtr;
+
+    auto portPtr = std::make_shared<display_port_t>();
+    YAML::convert<DisplayPortPtr>::decode(node["display_port_t"], portPtr);
+    mptr->dispPort= *portPtr;
+
+    return true;
+}
+
+bool YAML::convert<BufferInfoEventPtr>::decode(const YAML::Node& node, BufferInfoEventPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (! (node["display_event_t"] && node["display_event_t"].IsMap()))
+        return false;
+
+    if (! (node["buffer_info_t"] && node["buffer_info_t"].IsMap()))
+        return false;
+
+    auto eventPtr = std::make_shared<display_event_t>();
+    YAML::convert<DisplayEventPtr>::decode(node["display_event_t"], eventPtr);
+    mptr->event = *eventPtr;
+
+    auto infoPtr = std::make_shared<buffer_info_t>();
+    YAML::convert<BufferInfoPtr>::decode(node["buffer_info_t"], infoPtr);
+    mptr->info= *infoPtr;
+
+    return true;
+}
+
+bool YAML::convert<SetAlphaPtr>::decode(const YAML::Node& node, SetAlphaPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    mptr->enable     = node["enable"].as<unsigned int>();
+    GetSequence<unsigned int>(node["reserved"], mptr->reserved);
+
+    return true;
+}
+
+bool YAML::convert<SetAlphaEventPtr>::decode(const YAML::Node& node, SetAlphaEventPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (! (node["display_event_t"] && node["display_event_t"].IsMap()))
+        return false;
+
+    if (! (node["set_video_alpha_t"] && node["set_video_alpha_t"].IsMap()))
+        return false;
+
+    auto eventPtr = std::make_shared<display_event_t>();
+    YAML::convert<DisplayEventPtr>::decode(node["display_event_t"], eventPtr);
+    mptr->event = *eventPtr;
+
+    auto alphaPtr = std::make_shared<set_video_alpha_t>();
+    YAML::convert<SetAlphaPtr>::decode(node["set_video_alpha_t"], alphaPtr);
+    mptr->alpha= *alphaPtr;
+
+    return true;
+}
+
+bool YAML::convert<DisplayCtrlPtr>::decode(const YAML::Node& node, DisplayCtrlPtr &mptr)
+{
+    if (mptr == nullptr || !node.IsMap())
+        return false;
+
+    if (! (node["viewport"] && node["viewport"].IsMap()))
+        return false;
+
+    mptr->alpha     = node["alpha"].as<unsigned int>();
+    mptr->top_layer = node["top_layer"].as<unsigned int>();
+    mptr->rotation  = node["rotation"].as<unsigned int>();
+    mptr->reserved  = node["reserved"].as<unsigned int>();
+
+    YAML::Node viewport = node["viewport"];
+    mptr->viewport.l = viewport["l"].as<int16_t>();
+    mptr->viewport.t = viewport["t"].as<int16_t>();
+    mptr->viewport.r = viewport["r"].as<int16_t>();
+    mptr->viewport.b = viewport["b"].as<int16_t>();
+
+    return true;
+}

--- a/aic-emu/YmlParser.h
+++ b/aic-emu/YmlParser.h
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __YML_PARSER__
+#define __YML_PARSER__
+
+#include "display-protocol.h"
+#include "yaml-cpp/yaml.h"
+
+struct AicEventMetadata_t;
+
+using namespace vhal::client;
+
+using AicEventMetadataPtr = std::shared_ptr<AicEventMetadata_t>;
+using DisplayEventPtr     = std::shared_ptr<display_event_t>;
+using DisplayInfoPtr      = std::shared_ptr<display_info_t>;
+using DisplayPortPtr      = std::shared_ptr<display_port_t>;
+using BufferInfoPtr       = std::shared_ptr<buffer_info_t>;
+using CrosGrallocHandlePtr = std::shared_ptr<struct cros_gralloc_handle>;
+
+using DisplayInfoEventPtr = std::shared_ptr<display_info_event_t>;
+using DisplayPortEventPtr = std::shared_ptr<display_port_event_t>;
+using BufferInfoEventPtr  = std::shared_ptr<buffer_info_event_t>;
+
+using SetAlphaPtr         = std::shared_ptr<set_video_alpha_t>;
+using SetAlphaEventPtr    = std::shared_ptr<display_set_video_alpha_event_t>;
+using DisplayCtrlPtr      = std::shared_ptr<display_control_t>;
+
+namespace YAML
+{
+    template <> struct convert<AicEventMetadataPtr> {
+        static bool decode(const Node& node, AicEventMetadataPtr &mptr);
+    };
+
+    template <> struct convert<DisplayEventPtr> {
+        static bool decode(const Node& node, DisplayEventPtr &mptr);
+    };
+
+    template <> struct convert<DisplayInfoPtr> {
+        static bool decode(const Node& node, DisplayInfoPtr &mptr);
+    };
+
+    template <> struct convert<DisplayPortPtr> {
+        static bool decode(const Node& node, DisplayPortPtr &mptr);
+    };
+
+    template <> struct convert<BufferInfoPtr> {
+        static bool decode(const Node& node, BufferInfoPtr &mptr);
+    };
+
+    template <> struct convert<CrosGrallocHandlePtr> {
+        static bool decode(const Node& node, CrosGrallocHandlePtr &mptr);
+    };
+
+    template <> struct convert<DisplayInfoEventPtr> {
+        static bool decode(const Node& node, DisplayInfoEventPtr &mptr);
+    };
+
+    template <> struct convert<DisplayPortEventPtr> {
+        static bool decode(const Node& node, DisplayPortEventPtr &mptr);
+    };
+
+    template <> struct convert<BufferInfoEventPtr> {
+        static bool decode(const Node& node, BufferInfoEventPtr &mptr);
+    };
+
+    template <> struct convert<SetAlphaPtr> {
+        static bool decode(const Node& node, SetAlphaPtr &mptr);
+    };
+
+    template <> struct convert<SetAlphaEventPtr> {
+        static bool decode(const Node& node, SetAlphaEventPtr &mptr);
+    };
+
+    template <> struct convert<DisplayCtrlPtr> {
+        static bool decode(const Node& node, DisplayCtrlPtr &mptr);
+    };
+}
+#endif

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -17,6 +17,7 @@ list (APPEND SOURCES virtual_input_receiver.cc)
 list (APPEND SOURCES hwc_vhal.cc)
 list (APPEND SOURCES virtual_gps_receiver.cc)
 list (APPEND SOURCES command_channel_interface.cc)
+list (APPEND SOURCES hwc_profile_log.cc)
 
 # Build libvhal-client
 add_library(${PROJECT_NAME} SHARED ${SOURCES})

--- a/source/hwc_profile_log.cc
+++ b/source/hwc_profile_log.cc
@@ -1,0 +1,569 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "hwc_profile_log.h"
+#include <chrono>
+#include <cassert>
+
+using std::chrono::duration_cast;
+using std::chrono::microseconds;
+using std::chrono::system_clock;
+
+char evNames[][MAX_STRING_LENGTH] = {
+    "EVENT_INITIALIZE",
+    "VHAL_DD_EVENT_CREATE_BUFFER",
+    "VHAL_DD_EVENT_REMOVE_BUFFER",
+    "VHAL_DD_EVENT_DISPLAY_REQ",
+    "VHAL_DD_EVENT_DISPINFO_REQ",
+    "VHAL_DD_EVENT_DISPPORT_REQ",
+    "VHAL_DD_EVENT_DISPLAY_ACK",
+    "VHAL_DD_EVENT_DISPINFO_ACK",
+    "VHAL_DD_EVENT_DISPPORT_ACK"  ,
+    "VHAL_DD_EVENT_SETUP_RESOLUTION",
+    "VHAL_DD_EVENT_SET_VIDEO_ALPHA_REQ",
+    "EVENT_UNKNOWN"
+};
+
+void intArrayToString(string& tmpString, int length, int* intArray)
+{
+    assert(intArray != nullptr);
+
+    tmpString = "[";
+    for (int i = 0; i < length - 1; i++)
+        tmpString += to_string(intArray[i]) + ", ";
+    tmpString += to_string(intArray[length - 1]) + "]";
+
+    return;
+}
+
+void ProfileLogger::SetResolution(int width, int height)
+{
+    m_width = width;
+    m_height = height;
+}
+
+bool ProfileLogger::isSendEvent(log_event_t event)
+{
+    return (event >= SEND_EVENTS_START);
+}
+
+log_event_t ProfileLogger::TranslateEvType(int event)
+{
+    log_event_t translatedEvent;
+    switch (event)
+    {
+        case VHAL_DD_EVENT_DISPINFO_REQ:
+            translatedEvent = EVENT_DISPINFO_REQ; break;
+        case VHAL_DD_EVENT_DISPINFO_ACK:
+            translatedEvent = EVENT_DISPINFO_REQ_ACK ; break;
+        case VHAL_DD_EVENT_CREATE_BUFFER:
+            translatedEvent = EVENT_CREATE_BUFFER; break;
+        case VHAL_DD_EVENT_REMOVE_BUFFER:
+            translatedEvent = EVENT_REMOVE_BUFFER; break;
+        case VHAL_DD_EVENT_DISPLAY_REQ:
+            translatedEvent = EVENT_DISPLAY_REQ; break;
+        case VHAL_DD_EVENT_DISPLAY_ACK:
+            translatedEvent = EVENT_DISPLAY_REQ_ACK; break;
+        case VHAL_DD_EVENT_DISPPORT_REQ:
+            translatedEvent = EVENT_DISPPORT_REQ; break;
+        case VHAL_DD_EVENT_DISPPORT_ACK:
+            translatedEvent = EVENT_DISPPORT_REQ_ACK; break;
+        case VHAL_DD_EVENT_SETUP_RESOLUTION:
+            translatedEvent = EVENT_CHANGE_RESOLUTION; break;
+        case VHAL_DD_EVENT_SET_VIDEO_ALPHA_REQ:
+            translatedEvent = EVENT_SET_ALPHA; break;
+        default:
+            translatedEvent = EVENT_UNKNOWN; break;
+    }
+
+    return translatedEvent;
+}
+
+log_err_t ProfileLogger::Initialize(int width, int height)
+{
+    char* env_string = nullptr;
+    env_string = getenv("ENABLE_PROFILE_YMLLOG");
+
+    if (env_string != nullptr && atoi(env_string) == 1)
+    {
+        printf("YML Log of events is enabled\n");
+        m_enabled = true;
+    }
+
+    if (m_enabled == false)
+        return ERR_NONE;
+
+    env_string = getenv("YMLLOG_PATH");
+    if (env_string != nullptr)
+        m_logFilePath= env_string;
+
+    m_logFilePtr = fopen(m_logFilePath.c_str(), "w");
+    if (! m_logFilePtr) {
+        printf("Cannot open file to write: %s\n", m_logFilePath.c_str());
+        m_enabled = false;
+        return ERR_UNWRITABLE_LOGFILE;
+    }
+    else
+        printf("YML Log file opened at %s\n", m_logFilePath.c_str());
+
+    SetResolution(width, height);
+    m_initialized = true;
+
+    //Comments to clarify the log
+    WriteYmlLog(0, "# This log captures events submitted to libvhal and ICR shared lib");
+    WriteYmlLog(0, "# Events Code:");
+    for (int i = 1; i < EVENT_TYPE_COUNT; i++)
+        WriteYmlLog(0, "# %d: %s", i, evNames[i]);
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AcquireMutex()
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+
+    try {
+        m_log_mutex.lock();
+    }
+    catch (std::system_error& e) {
+        std::cout << "Exception attempting to acquire log mutex: " << e.code()
+                  << " (" << e.what() << ")" << std::endl;
+        return ERR_LOCKING;
+    }
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::ReleaseMutex()
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+
+    try {
+        m_log_mutex.unlock();
+    }
+    catch (std::system_error& e) {
+        std::cout << "Exception attempting to release log mutex: " << e.code()
+                  << " (" << e.what() << ")" << std::endl;
+        return ERR_LOCKING;
+    }
+
+    return ERR_NONE;
+}
+
+int ProfileLogger::CheckProtocol_BufferInfoEvent(log_event_t event)
+{
+    //This function checks if display_event_t struct received should be logged as part
+    //of a buffer_info_event_t struct in the display protocol.
+    //The return value indicates the level for the Subsequent structures to be dumped
+
+    int nextStructLevel = 1;
+
+    if (event == EVENT_CREATE_BUFFER ||
+        event == EVENT_REMOVE_BUFFER ||
+        event == EVENT_DISPLAY_REQ)
+    {
+        WriteYmlLog(1, "buffer_info_event_t:");
+        WriteYmlLog(2, "struct_size: %lu", sizeof(buffer_info_event_t));
+        nextStructLevel += 1;
+    }
+
+    return nextStructLevel;
+}
+
+
+log_err_t ProfileLogger::LogGenericEventInfo(log_event_t type, display_event_t* ev)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+
+    auto us_since_epoch = duration_cast<microseconds>(system_clock::now().time_since_epoch()).count();
+
+    //If not first event, mark end of previous document (each event is one YML "document")
+    //This is required to simplify parsing of the generated YML
+    //End of document is an optional flag, so it isn't a problem if the end of the last doc isn't marked.
+    if (m_reportId != 0)
+        WriteYmlLog(0, "\n...");
+    //Mark beginning of new YML document
+    WriteYmlLog(0, "\n---");
+
+    //Write Event related data
+    WriteYmlLog(0, "event:");
+    WriteYmlLog(1, "metadata:");
+    WriteYmlLog(2, "eventId: %d", m_reportId);
+    WriteYmlLog(2, "eventName: %s", evNames[type]);
+    WriteYmlLog(2, "direction: %s", isSendEvent(type) ? "send" : "receive");
+    WriteYmlLog(2, "timeStampUs: %ld", (long int)us_since_epoch);
+    WriteYmlLog(2, "counts:");
+    WriteYmlLog(3, "CreateBufferEvents: %d", m_createBufEventCnt);
+    WriteYmlLog(3, "RemoveBufferEvents: %d", m_removeBufEventCnt);
+    WriteYmlLog(3, "DisplayReqEvents: %d", m_displayReqEventCnt);
+    WriteYmlLog(3, "ChangeResolutionEvents: %d", m_changeResolutionCnt);
+    WriteYmlLog(3, "DispInfoReqEvents: %d", m_dispInfoReqEventCnt);
+    WriteYmlLog(3, "DispPortReqEvents: %d", m_dispPortReqEventCnt);
+    WriteYmlLog(3, "SetAlphaEvents: %d", m_setAlphaCnt);
+
+    m_reportId++;
+
+    log_err_t res = ERR_NONE;
+    if (ev)
+    {
+        int level = CheckProtocol_BufferInfoEvent(type);
+        res = AddDisplayEventStruct(ev, level);
+    }
+    return res;
+}
+
+log_err_t ProfileLogger::AddDisplayInfoEventStruct(display_info_event_t* ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+
+    int fl = level + 1; //fieldLevel
+    WriteYmlLog(level, "display_info_event_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_info_event_t));
+
+    RET_IF_FAIL(AddDisplayEventStruct(&ev->event, fl));
+    return AddDisplayInfoStruct(&ev->info, fl);
+}
+
+log_err_t ProfileLogger::AddBufferInfoEventStruct(buffer_info_event_t* ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+
+    int fl = level + 1; //fieldLevel
+    WriteYmlLog(level, "buffer_info_event_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(buffer_info_event_t));
+
+    RET_IF_FAIL(AddDisplayEventStruct(&ev->event, fl));
+    return AddBufferInfoStruct(&ev->info, fl);
+}
+
+log_err_t ProfileLogger::AddDisplayPortEventStruct(display_port_event_t* ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+
+    int fl = level + 1; //fieldLevel
+    WriteYmlLog(level, "display_port_event_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_port_event_t));
+
+    RET_IF_FAIL(AddDisplayEventStruct(&ev->event, fl));
+    return AddDisplayPortStruct(&ev->dispPort, fl);
+}
+
+log_err_t ProfileLogger::AddDisplayEventStruct(display_event_t* ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+
+    int fl = level + 1; //fieldLevel
+
+    WriteYmlLog(level, "display_event_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_event_t));
+    WriteYmlLog(fl, "type: 0x%X", ev->type);
+    WriteYmlLog(fl, "size: %d", ev->size);
+    WriteYmlLog(fl, "id: %d", ev->id);
+    WriteYmlLog(fl, "renderNode: %d", ev->renderNode);
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddDisplayInfoStruct(display_info_t* ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (ev == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1; //fieldLevel
+
+    WriteYmlLog(level, "display_info_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_info_t));
+    WriteYmlLog(fl ,"flags: 0x%X", ev->flags);
+    WriteYmlLog(fl, "width: %d", ev->width);
+    WriteYmlLog(fl, "height: %d", ev->height);
+    WriteYmlLog(fl, "stride: %d", ev->stride);
+    WriteYmlLog(fl, "format: %d", ev->format);
+    WriteYmlLog(fl, "xdpi: %f", ev->xdpi);
+    WriteYmlLog(fl, "ydpi: %f", ev->ydpi);
+    WriteYmlLog(fl, "fps: %f", ev->fps);
+    WriteYmlLog(fl, "minSwapInterval: %d", ev->minSwapInterval);
+    WriteYmlLog(fl, "maxSwapInterval: %d", ev->maxSwapInterval);
+    WriteYmlLog(fl, "numFramebuffers: %d", ev->numFramebuffers);
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddGrallocHandleStruct(cros_gralloc_handle_t handle, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (handle == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    string tmpString;
+    int fl = level + 1; //field level
+
+    WriteYmlLog(level, "cros_gralloc_handle_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(struct cros_gralloc_handle));
+
+    AddNativeHandleStruct(&handle->base, fl);
+
+    intArrayToString(tmpString, DRV_MAX_PLANES, (int*)handle->fds);
+    WriteYmlLog(fl, "fds: %s", tmpString.c_str());
+    intArrayToString(tmpString, DRV_MAX_PLANES, (int*)handle->strides);
+    WriteYmlLog(fl, "strides: %s", tmpString.c_str());
+    intArrayToString(tmpString, DRV_MAX_PLANES, (int*)handle->offsets);
+    WriteYmlLog(fl, "offsets: %s", tmpString.c_str());
+    intArrayToString(tmpString, DRV_MAX_PLANES, (int*)handle->sizes);
+    WriteYmlLog(fl, "sizes: %s", tmpString.c_str());
+    intArrayToString(tmpString, DRV_MAX_PLANES*2, (int*)handle->format_modifiers);
+    WriteYmlLog(fl, "format_modifiers: %s", tmpString.c_str());
+
+    WriteYmlLog(fl, "width: %d", handle->width);
+    WriteYmlLog(fl, "height: %d", handle->height);
+    WriteYmlLog(fl, "format: %d", handle->format);
+    WriteYmlLog(fl, "tiling_mode: %d", handle->tiling_mode);
+
+    intArrayToString(tmpString, 2, (int*)handle->use_flags);
+    WriteYmlLog(fl, "use_flags: %s", tmpString.c_str());
+
+    WriteYmlLog(fl, "magic: %u", handle->magic);
+    WriteYmlLog(fl, "pixel_stride: %d", handle->pixel_stride);
+    WriteYmlLog(fl, "droid_format: %d", handle->droid_format);
+    WriteYmlLog(fl, "usage: %d", handle->usage);
+    WriteYmlLog(fl, "consumer_usage: %d", handle->consumer_usage);
+    WriteYmlLog(fl, "producer_usage: %d", handle->producer_usage);
+    WriteYmlLog(fl, "yuv_color_range: %d", handle->yuv_color_range);
+    WriteYmlLog(fl, "is_updated: %d", handle->is_updated);
+    WriteYmlLog(fl, "is_encoded: %d", handle->is_encoded);
+    WriteYmlLog(fl, "is_encrypted: %d", handle->is_encrypted);
+    WriteYmlLog(fl, "is_key_frame: %d", handle->is_key_frame);
+    WriteYmlLog(fl, "is_interlaced: %d", handle->is_interlaced);
+    WriteYmlLog(fl, "is_mmc_capable: %d", handle->is_mmc_capable);
+    WriteYmlLog(fl, "compression_mode: %d", handle->compression_mode);
+    WriteYmlLog(fl, "compression_hint: %d", handle->compression_hint);
+    WriteYmlLog(fl, "codec: %d", handle->codec);
+    WriteYmlLog(fl, "aligned_width: %d", handle->aligned_width);
+    WriteYmlLog(fl, "aligned_height: %d", handle->aligned_height);
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddNativeHandleStruct(native_handle_t* handle, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (handle == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1; //field level
+    WriteYmlLog(level, "native_handle_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(native_handle_t));
+
+    WriteYmlLog(fl, "version: %d", handle->version);
+    WriteYmlLog(fl, "numFds: %d", handle->numFds);
+    WriteYmlLog(fl, "numInts: %d", handle->numInts);
+    WriteYmlLog(fl, "data: %ld", sizeof(handle->data));
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddDisplayPortStruct(display_port_t* dp, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (dp == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1; //field level
+    WriteYmlLog(level, "display_port_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_port_t));
+
+    WriteYmlLog(fl, "port: %d", dp->port);
+    WriteYmlLog(fl, "reserve: %d", dp->reserve);
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddBufferInfoStruct(buffer_info_t* handle, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (handle == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1; //field level
+    WriteYmlLog(level, "buffer_info_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(buffer_info_t));
+    WriteYmlLog(fl, "remote_handle: %ld", handle->remote_handle);
+    WriteYmlLog(fl, "data: %ld", sizeof(handle->data));
+
+    return ERR_NONE;
+}
+
+void ProfileLogger::UpdateEventCount(log_event_t event)
+{
+    if (!IsEnabled())
+        return;
+
+    switch (event)
+    {
+        case EVENT_CREATE_BUFFER:
+            m_createBufEventCnt++; break;
+        case EVENT_REMOVE_BUFFER:
+            m_removeBufEventCnt++; break;
+        case EVENT_DISPLAY_REQ:
+            m_displayReqEventCnt++; break;
+        case EVENT_DISPINFO_REQ:
+            m_dispInfoReqEventCnt++; break;
+        case EVENT_DISPPORT_REQ:
+            m_dispInfoReqEventCnt++; break;
+        case EVENT_CHANGE_RESOLUTION:
+            m_changeResolutionCnt++; break;
+        case EVENT_SET_ALPHA:
+            m_setAlphaCnt++; break;
+        default:
+            break;
+    }
+}
+
+log_err_t ProfileLogger::LogChangeResolutionEvent(int width, int height, display_info_event_t* ev)
+{
+    SetResolution(width, height);
+    UpdateEventCount(EVENT_CHANGE_RESOLUTION);
+
+    AcquireMutex();
+
+    LogGenericEventInfo(EVENT_CHANGE_RESOLUTION);
+    AddDisplayInfoEventStruct(ev);
+
+    ReleaseMutex();
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddSetVideoAlphaStruct(set_video_alpha_t* alpha, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (alpha == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1;
+    WriteYmlLog(level, "set_video_alpha_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(set_video_alpha_t));
+
+    string tmpString;
+    intArrayToString(tmpString, sizeof(alpha->reserved)/sizeof(uint32_t), (int *)alpha->reserved);
+
+    WriteYmlLog(fl, "enable: %d", alpha->enable);
+    WriteYmlLog(fl, "reserved: %s", tmpString.c_str());
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddVideoAlphaEventStruct(display_set_video_alpha_event_t* alpha_ev, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (alpha_ev == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1;
+    WriteYmlLog(level, "display_set_video_alpha_event_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_set_video_alpha_event_t));
+
+    RET_IF_FAIL(AddDisplayEventStruct(&alpha_ev->event, fl));
+
+    return AddSetVideoAlphaStruct(&alpha_ev->alpha, fl);
+}
+
+log_err_t ProfileLogger::LogSetAlphaEvent(display_set_video_alpha_event_t* alpha_ev)
+{
+    UpdateEventCount(EVENT_SET_ALPHA);
+
+    AcquireMutex();
+
+    LogGenericEventInfo(EVENT_SET_ALPHA);
+
+    AddVideoAlphaEventStruct(alpha_ev);
+
+    ReleaseMutex();
+
+    return ERR_NONE;
+}
+
+log_err_t ProfileLogger::AddDisplayControlStruct(display_control_t* ctrl, int level)
+{
+    if (!IsEnabled())
+        return ERR_NONE;
+    if (m_initialized == false)
+        return ERR_UNINITIALIZED;
+    if (ctrl == nullptr)
+        return ERR_NULL_SRC_DATA;
+
+    int fl = level + 1;
+    WriteYmlLog(level, "display_control_t:");
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(display_control_t));
+
+    WriteYmlLog(fl, "alpha: %d", ctrl->alpha);
+    WriteYmlLog(fl, "top_layer: %d", ctrl->top_layer);
+    WriteYmlLog(fl, "rotation: %d",  ctrl->rotation);
+    WriteYmlLog(fl, "reserved: %d",  ctrl->reserved);
+
+    WriteYmlLog(fl, "viewport:");
+    fl++;
+    WriteYmlLog(fl, "struct_size: %lu", sizeof(ctrl->viewport));
+    WriteYmlLog(fl, "l: %d", ctrl->viewport.l);
+    WriteYmlLog(fl, "t: %d", ctrl->viewport.t);
+    WriteYmlLog(fl, "r: %d", ctrl->viewport.r);
+    WriteYmlLog(fl, "b: %d", ctrl->viewport.b);
+
+    return ERR_NONE;
+}

--- a/source/hwc_profile_log.h
+++ b/source/hwc_profile_log.h
@@ -1,0 +1,155 @@
+/**
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __HWC_PROFILE_LOG__
+#define __HWC_PROFILE_LOG__
+
+#include <iostream>
+#include <cstdio>
+#include <string>
+#include <mutex>
+#include "display-protocol.h"
+
+using namespace vhal::client;
+using std::string;
+using std::to_string;
+
+#define DEFAULT_LOGFILE_NAME "/tmp/ICR.yml"
+#define MAX_STRING_LENGTH 1024
+#define MAX_FILENAME_LENGTH MAX_STRING_LENGTH
+#define SPC4 "    "
+
+#define WriteYmlLog(level, ...)                 \
+    do  {                                       \
+        for (int i = 0; i < (level); i++) {     \
+            fprintf(m_logFilePtr, "%s", SPC4);  \
+        }                                       \
+        fprintf(m_logFilePtr,  __VA_ARGS__);    \
+        fprintf(m_logFilePtr, "\n");            \
+        fflush(m_logFilePtr);                   \
+    }  while(0);
+
+#define RET_IF_FAIL(statements)                 \
+    do {                                        \
+        log_err_t res = (statements);           \
+        if (res != ERR_NONE)                    \
+            return res;                         \
+    }                                           \
+    while(0);
+
+enum log_err_t
+{
+    ERR_NONE = 0,
+    ERR_UNWRITABLE_LOGFILE = 1,
+    ERR_UNINITIALIZED=2,
+    ERR_NULL_SRC_DATA=3,
+    ERR_LOCKING=4,
+    ERR_UNKNOWN=5,
+    ERR_TYPE_COUNT
+};
+
+enum log_event_t
+{
+    EVENT_INITIALIZE = 0,
+    RECV_EVENTS_START,
+    EVENT_CREATE_BUFFER = RECV_EVENTS_START ,
+    EVENT_REMOVE_BUFFER,
+    EVENT_DISPLAY_REQ,
+    EVENT_DISPINFO_REQ,
+    EVENT_DISPPORT_REQ,
+    SEND_EVENTS_START,
+    EVENT_DISPLAY_REQ_ACK = SEND_EVENTS_START,
+    EVENT_DISPINFO_REQ_ACK,
+    EVENT_DISPPORT_REQ_ACK,
+    EVENT_CHANGE_RESOLUTION,
+    EVENT_SET_ALPHA,
+    EVENT_UNKNOWN,
+    EVENT_TYPE_COUNT
+};
+
+class ProfileLogger
+{
+public:
+    ProfileLogger(const char* fname = nullptr)
+    {
+        m_logFilePath = (fname != nullptr) ? fname : DEFAULT_LOGFILE_NAME;
+    }
+
+    ~ProfileLogger()
+    {
+        if(m_logFilePtr)
+            fclose(m_logFilePtr);
+    }
+
+    log_err_t Initialize(int width=0, int height=0);
+    log_err_t LogGenericEventInfo(log_event_t eventType, display_event_t* ev=nullptr);
+    log_err_t LogChangeResolutionEvent(int width, int height, display_info_event_t* ev);
+    log_err_t LogSetAlphaEvent(display_set_video_alpha_event_t* alpha_ev);
+
+    log_err_t AddDisplayInfoEventStruct(display_info_event_t* ev, int level=1);
+    log_err_t AddBufferInfoEventStruct(buffer_info_event_t* ev, int level=1);
+    log_err_t AddDisplayPortEventStruct(display_port_event_t* ev, int level=1);
+
+    log_err_t AddDisplayEventStruct(display_event_t* ev, int level=1);
+    log_err_t AddDisplayInfoStruct(display_info_t* ev, int level=1);
+    log_err_t AddGrallocHandleStruct(cros_gralloc_handle_t handle, int level=1);
+    log_err_t AddNativeHandleStruct(native_handle_t* handle, int level=1);
+    log_err_t AddDisplayPortStruct(display_port_t* dp, int level=1);
+    log_err_t AddBufferInfoStruct(buffer_info_t* handle, int level=1);
+
+    log_err_t AddSetVideoAlphaStruct(set_video_alpha_t* alpha, int level=1);
+    log_err_t AddVideoAlphaEventStruct(display_set_video_alpha_event_t* alpha_ev, int level=1);
+    log_err_t AddDisplayControlStruct(display_control_t* ctrl, int level=1);
+
+    bool isSendEvent(log_event_t event);
+    log_event_t TranslateEvType(int event);
+    void UpdateEventCount(log_event_t event);
+    void SetResolution(int width, int height);
+    int CheckProtocol_BufferInfoEvent(log_event_t event);
+
+    inline bool IsEnabled() { return m_enabled; }
+
+    log_err_t AcquireMutex();
+    log_err_t ReleaseMutex();
+
+protected:
+    string m_logFilePath;
+    FILE* m_logFilePtr = nullptr;
+
+    bool m_enabled = false;
+    bool m_initialized = false;
+    int m_width  = 0;
+    int m_height = 0;
+
+    int m_reportId = 0;
+    int m_createBufEventCnt    = 0;
+    int m_removeBufEventCnt    = 0;
+    int m_displayReqEventCnt   = 0;
+    int m_changeResolutionCnt  = 0;
+    int m_dispInfoReqEventCnt  = 0;
+    int m_dispPortReqEventCnt  = 0;
+    int m_setAlphaCnt          = 0;
+
+    //Two threads send msgs to AiC. They both need to write to same log file and need mutex to avoid overlap
+    //One of these threads also receives and responds to AiC events. This threads sends ACKs to AiC messages
+    //Another thread handles pipe messages from client, that get forwarded to AiC
+    std::mutex m_log_mutex;
+};
+
+#endif

--- a/source/hwc_vhal_impl.h
+++ b/source/hwc_vhal_impl.h
@@ -31,6 +31,7 @@
 #include "istream_socket_client.h"
 
 #include "display-protocol.h"
+#include "hwc_profile_log.h"
 using namespace std;
 
 #define fourcc_code(a,b,c,d) ((uint32_t)(a) | ((uint32_t)(b) << 8) | \
@@ -52,13 +53,16 @@ public:
         AIC_LOG(mDebug, "info.user_id: %d", info.user_id);
         AIC_LOG(mDebug, "info.unix_conn_info.socket_dir: %s", info.unix_conn_info.socket_dir.c_str());
         AIC_LOG(mDebug, "info.unix_conn_info.android_instance_id: %d", info.unix_conn_info.android_instance_id);
+
+        m_pLog = std::make_unique<ProfileLogger>();
+        m_pLog->Initialize(info.video_res_width, info.video_res_height);
     }
 
     ~Impl()
     {
         if (should_continue_) {
             stop();
-	}
+        }
     }
 
     cros_gralloc_handle_t get_handle(uint64_t h)
@@ -209,6 +213,8 @@ public:
             error_msg = std::strerror(errno);
             return {-1, error_msg};
         }
+        m_pLog->LogChangeResolutionEvent(width, height, &ev);
+
         return {0, error_msg};
     }
 
@@ -232,6 +238,8 @@ public:
             error_msg = std::strerror(errno);
             return {-1, error_msg};
         }
+        m_pLog->LogSetAlphaEvent(&ev);
+
         return {0, error_msg};
     }
 
@@ -275,6 +283,12 @@ public:
                     AIC_LOG(mDebug, "client disconnected: %s\n", strerror(errno));
                     break;
                 } else {
+                    log_event_t eventType = m_pLog->TranslateEvType(ev.type);
+                    m_pLog->UpdateEventCount(eventType);
+
+                    m_pLog->AcquireMutex();
+                    m_pLog->LogGenericEventInfo(eventType, &ev);
+
                     switch (ev.type) {
                         case VHAL_DD_EVENT_DISPINFO_REQ:
                           if (checkDispConfig(ev.id, ev.renderNode) == -1) {
@@ -305,6 +319,8 @@ public:
                           AIC_LOG(mDebug, "VHAL_DD_EVENT_<unknown>: ev.type=%d\n", ev.type);
                           break;
                     } // end of switch
+
+                    m_pLog->ReleaseMutex();
                 } //end of else
             }
         } // end of while
@@ -360,6 +376,9 @@ public:
         if (len <= 0) {
             AIC_LOG(mDebug, "send() failed: %s\n", strerror(errno));
         }
+
+        m_pLog->LogGenericEventInfo(EVENT_DISPINFO_REQ_ACK);
+        m_pLog->AddDisplayInfoEventStruct(&ev);
     }
 
     void UpdateDispPort(int fd) {
@@ -374,6 +393,9 @@ public:
       if (len <= 0) {
           AIC_LOG(mDebug, "send() failed: %s\n", strerror(errno));
       }
+
+      m_pLog->LogGenericEventInfo(EVENT_DISPPORT_REQ_ACK);
+      m_pLog->AddDisplayPortEventStruct(&ev);
     }
 
     /* msg has 2 parts: header and body
@@ -404,6 +426,7 @@ public:
             AIC_LOG(mDebug, "Failed to read buffer info: %s\n", strerror(errno));
             return -1;
         }
+        m_pLog->AddBufferInfoStruct(&ev.info, 2);
 
         len = recv(fd, handle, sizeof(cros_gralloc_handle), 0);
         if (len <= 0) {
@@ -411,6 +434,7 @@ public:
             AIC_LOG(mDebug, "Failed to read buffer info: %s\n", strerror(errno));
             return -1;
         }
+
         if (recvFds(fd, handle->fds, handle->base.numFds) == -1) {
             free(handle);
             return -1;
@@ -419,6 +443,10 @@ public:
         if (handle->format == DRM_FORMAT_NV12_Y_TILED_INTEL) {
             handle->format = DRM_FORMAT_NV12;
         }
+
+        //Dump YML log after file descriptors are captured into "handle"
+        m_pLog->AddGrallocHandleStruct(handle, 2);
+
         AIC_LOG(mDebug, "createBuffer width(%d)height(%d)\n", handle->width, handle->height);
         mHandles.insert(std::make_pair(ev.info.remote_handle, handle));
         frame_info_t frame = {.handle = handle, .ctrl = nullptr};
@@ -437,6 +465,7 @@ public:
             AIC_LOG(mDebug, "Failed to read buffer info: %s\n", strerror(errno));
             return -1;
         }
+        m_pLog->AddBufferInfoStruct(&ev.info, 2);
 
         cros_gralloc_handle_t handle = get_handle(ev.info.remote_handle);
         if (!handle) {
@@ -444,6 +473,7 @@ public:
         }
         frame_info_t frame = {.handle = handle, .ctrl = nullptr};
         mHwcHandler(FRAME_REMOVE, &frame);
+
         close(handle->fds[0]);
         free(handle);
 
@@ -464,6 +494,8 @@ public:
             AIC_LOG(mDebug, "Failed to read buffer info: %s\n", strerror(errno));
             return -1;
         }
+        m_pLog->AddBufferInfoStruct(&ev.info, 2);
+
         display_control_t ctrl{};
         bool hasCtrl = (size == (sizeof(ev.info) + sizeof(display_control_t)));
         if (hasCtrl) {
@@ -472,6 +504,7 @@ public:
                 AIC_LOG(mDebug, "Failed to read display control info: %s\n", strerror(errno));
                 return -1;
             }
+            m_pLog->AddDisplayControlStruct(&ctrl, 2);
         }
 
         cros_gralloc_handle_t handle = get_handle(ev.info.remote_handle);
@@ -489,6 +522,8 @@ public:
             AIC_LOG(mDebug, "send() failed: %s\n", strerror(errno));
             return -1;
         }
+        m_pLog->LogGenericEventInfo(EVENT_DISPLAY_REQ_ACK);
+        m_pLog->AddBufferInfoEventStruct(&ev);
 
         return 0;
     }
@@ -503,6 +538,7 @@ public:
         int sockClientFd = -1;
         int mDebug = 2;
         std::map<uint64_t, cros_gralloc_handle_t> mHandles;
+        std::unique_ptr<ProfileLogger> m_pLog;
 
 };
 }


### PR DESCRIPTION
Issue: VSMGWL-52000, VSMGWL-52001

- Log a profile of libvhal communication with AiC in YML format, in support of stand-alone testing of ICR.
  - Requires env variable ENABLE_PROFILE_YMLLOG=1 at runtime to be enabled
  - Log captured as a set of events, with each event capturing data received from a socket read/write.

- AicEmulator (aic-emu) app serves as stand-in to AiC 
    - Parses YML dumps and populates them into structures for ICR to process
    - Interfaces with i915 to create and populate Graphics Memory buffer objects
    - Relays test data to and from ICR by defined Display Protocol
    - Can be built optionally as part of ICR test container