### PR TITLE
Fixes and Extensions to Aic-Emu CmdLine options

### DIFF
--- a/aic-emu/AicEmu.cc
+++ b/aic-emu/AicEmu.cc
@@ -31,6 +31,7 @@ void Usage()
     std::cout << "\nNon-Mandatory options:" << std::endl;
     std::cout << "  --device <device path>   : Device path. Default /dev/dri/renderD128" << std::endl;
     std::cout << "  --instance <id num>      : Number indicating instance ID. Default 0" << std::endl;
+    std::cout << "  --manage-fps <0/1>       : Match fps with timestamps in yml log. Default Enabled(1)" << std::endl;
     return;
 }
 
@@ -67,6 +68,12 @@ int ParseArgs(AicConfigData_t& config, int argc, char** argv)
             if (++idx >= argc)
                 break;
             config.socketInfo.hwc_sock = std::string(argv[idx]);
+        }
+        else if (std::string("--manage-fps") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.manageFps = (atoi(argv[idx]) == 1) ? true : false;
         }
         else if (std::string("--instance") == argv[idx])
         {
@@ -108,7 +115,7 @@ int main(int argc, char** argv)
 {
     int status = AICS_ERR_NONE;
 
-    AicConfigData_t config = {  .socketInfo = {0} };
+    AicConfigData_t config = {  .socketInfo = {0} , .manageFps = true };
     status = ParseArgs(config, argc, argv);
     CHECK_STATUS(status);
 

--- a/aic-emu/AicEmu.cc
+++ b/aic-emu/AicEmu.cc
@@ -20,24 +20,16 @@
 #include <memory>
 #include "CmdHandler.h"
 
-struct AicConfigData_t
-{
-    std::string ymlFileName;
-    std::string contentFileName;
-    std::string deviceString;
-    AicSocketData_t socketInfo;
-};
-
 void Usage()
 {
     std::cout << "Usage: aic-emu <mandatory options> [non-mandatory options] " << std::endl;
+    std::cout << "--help, -h                 : Print this help and exit" << std::endl;
     std::cout << "\nMandatory options:" << std::endl;
-    std::cout << "  --cmd <yml file path>  : Path of YML file containing AiC cmd sequence" << std::endl;
-    std::cout << "  --content <clip path>  : Path of clip to serve as content" << std::endl;
-    std::cout << "  --hwc-sock <socketpath>: Path of Unix Socket file" << std::endl;
+    std::cout << "  --cmd <yml file path>    : Path of YML file containing AiC cmd sequence" << std::endl;
+    std::cout << "  --content <clip path>    : Path of clip to serve as content" << std::endl;
+    std::cout << "  --hwc-sock <socketpath>  : Path of Unix Socket file" << std::endl;
     std::cout << "\nNon-Mandatory options:" << std::endl;
-    std::cout << "  --device <device path> : Device path. Default /dev/dri/renderD128" << std::endl;
-    std::cout << "  --help, -h             : Print this help and exit" << std::endl;
+    std::cout << "  --device <device path>   : Device path. Default /dev/dri/renderD128" << std::endl;
     return;
 }
 
@@ -114,11 +106,11 @@ int main(int argc, char** argv)
 {
     int status = AICS_ERR_NONE;
 
-    AicConfigData_t config;
+    AicConfigData_t config = {  .socketInfo = {0} };
     status = ParseArgs(config, argc, argv);
     CHECK_STATUS(status);
 
-    auto handler = std::make_unique<CmdHandler>(config.ymlFileName, config.contentFileName, &config.socketInfo);
+    auto handler = std::make_unique<CmdHandler>(config);
     status = handler->Init();
     CHECK_STATUS(status);
 

--- a/aic-emu/AicEmu.cc
+++ b/aic-emu/AicEmu.cc
@@ -27,9 +27,10 @@ void Usage()
     std::cout << "\nMandatory options:" << std::endl;
     std::cout << "  --cmd <yml file path>    : Path of YML file containing AiC cmd sequence" << std::endl;
     std::cout << "  --content <clip path>    : Path of clip to serve as content" << std::endl;
-    std::cout << "  --hwc-sock <socketpath>  : Path of Unix Socket file" << std::endl;
+    std::cout << "  --hwc-sock <socket path> : Path of Unix Socket file. Note Instance ID (default 0) is appended internally." << std::endl;
     std::cout << "\nNon-Mandatory options:" << std::endl;
     std::cout << "  --device <device path>   : Device path. Default /dev/dri/renderD128" << std::endl;
+    std::cout << "  --instance <id num>      : Number indicating instance ID. Default 0" << std::endl;
     return;
 }
 
@@ -66,11 +67,12 @@ int ParseArgs(AicConfigData_t& config, int argc, char** argv)
             if (++idx >= argc)
                 break;
             config.socketInfo.hwc_sock = std::string(argv[idx]);
-
-            //Make rest of fields 0
-            config.socketInfo.session_id = 0;
-            config.socketInfo.user_id = 0;
-            config.socketInfo.android_instance_id = 0;
+        }
+        else if (std::string("--instance") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            config.socketInfo.session_id = atoi(argv[idx]);
         }
         else
         {

--- a/aic-emu/CmdHandler.cc
+++ b/aic-emu/CmdHandler.cc
@@ -38,22 +38,17 @@ CmdHandler::CmdHandler(AicConfigData_t& config):
     //Socket related data
     if (!config.socketInfo.hwc_sock.empty())
     {
-        std::string path = config.socketInfo.hwc_sock;
-        if (path.find("/hwc-sock") == std::string::npos)
-            return;
+        m_UnixConnInfo.socket_dir = config.socketInfo.hwc_sock;
+    }
 
-        size_t pos = path.find("/hwc-sock");
-        m_UnixConnInfo.socket_dir = path.substr(0, pos);
-
-        if (getenv("K8S_ENV") == NULL || strcmp(getenv("K8S_ENV"), "true") != 0) {
-            // docker env
-            m_UnixConnInfo.android_instance_id = config.socketInfo.session_id;
-        }
-        else
-        {
-            // k8s env
-            m_UnixConnInfo.android_instance_id = -1; //dont need id for k8s env
-        }
+    if (getenv("K8S_ENV") == NULL || strcmp(getenv("K8S_ENV"), "true") != 0) {
+        // docker env
+        m_UnixConnInfo.android_instance_id = config.socketInfo.session_id;
+    }
+    else
+    {
+        // k8s env
+        m_UnixConnInfo.android_instance_id = -1; //dont need id for k8s env
     }
 }
 
@@ -83,7 +78,6 @@ int CmdHandler::InitSocket()
     }
     else
     {
-        sockPath += HWC_UNIX_SOCKET;
         if (m_UnixConnInfo.android_instance_id >= 0) {
             sockPath += std::to_string(m_UnixConnInfo.android_instance_id);
         }

--- a/aic-emu/CmdHandler.cc
+++ b/aic-emu/CmdHandler.cc
@@ -26,17 +26,19 @@ using std::chrono::duration_cast;
 using std::chrono::microseconds;
 using std::chrono::system_clock;
 
-CmdHandler::CmdHandler(std::string ymlFile, std::string inputFile, AicSocketData_t* info):
-    m_ymlFileName(ymlFile),
-    m_inputFileName(inputFile),
+CmdHandler::CmdHandler(AicConfigData_t& config):
+    m_ymlFileName(config.ymlFileName),
+    m_inputFileName(config.contentFileName),
+    m_gfxDeviceStr(config.deviceString),
     m_props(nullptr),
     m_lastDispReqSentTS(0),
     m_lastDispReqYmlTS(0),
     m_firstDispReqSentTS(0)
 {
-    if (info)
+    //Socket related data
+    if (!config.socketInfo.hwc_sock.empty())
     {
-        std::string path = info->hwc_sock;
+        std::string path = config.socketInfo.hwc_sock;
         if (path.find("/hwc-sock") == std::string::npos)
             return;
 
@@ -45,7 +47,7 @@ CmdHandler::CmdHandler(std::string ymlFile, std::string inputFile, AicSocketData
 
         if (getenv("K8S_ENV") == NULL || strcmp(getenv("K8S_ENV"), "true") != 0) {
             // docker env
-            m_UnixConnInfo.android_instance_id = info->session_id;
+            m_UnixConnInfo.android_instance_id = config.socketInfo.session_id;
         }
         else
         {
@@ -549,8 +551,7 @@ int CmdHandler::InitGfxSurfaceHandler()
         return AICS_ERR_INPUT_STREAM;
 
     GfxStatus status = GFX_OK;
-    status = m_gfx.GfxInit();
-
+    status = m_gfx.GfxInit(m_gfxDeviceStr);
     if (status)
         return AICS_ERR_GFX;
 

--- a/aic-emu/CmdHandler.cc
+++ b/aic-emu/CmdHandler.cc
@@ -188,6 +188,7 @@ int CmdHandler::Xchng_DisplayRequest(std::vector<std::shared_ptr<void>>& payload
         return AICS_ERR_PAYLOAD_EMPTY;
 
     auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+    evInfo->event.renderNode = m_gfx.GetRenderNode(); //Override with device being used
 
     // Check if payload data is consistent
     int requestSize = evInfo->event.size - sizeof(display_event_t);
@@ -264,6 +265,8 @@ int CmdHandler::DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEve
 
             //send display_event_t
             auto event = std::static_pointer_cast<display_event_t>(payload[0]);
+            event->renderNode = m_gfx.GetRenderNode(); //Override with device being used
+
             status = WriteIntoSocket(event.get(), sizeof(display_event_t));
             CHECK_STATUS(status);
             break;
@@ -273,6 +276,8 @@ int CmdHandler::DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEve
             AIC_LOG();
             //send display_event_t + buffer_info_t + cros_gralloc_handle + Special FDs msg
             auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+            evInfo->event.renderNode = m_gfx.GetRenderNode(); //Override with device being used
+
             auto grallocHandle = std::static_pointer_cast<cros_gralloc_handle, void>(payload[1]);
             m_props = grallocHandle;
             std::cout << "width = " << m_props->width << " , height = " << m_props->height << std::endl;
@@ -305,6 +310,7 @@ int CmdHandler::DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEve
             AIC_LOG();
             //send display_event_t + buffer_info_t
             auto evInfo = std::static_pointer_cast<buffer_info_event_t, void>(payload[0]);
+            evInfo->event.renderNode = m_gfx.GetRenderNode(); //Override with device being used
 
             status = WriteIntoSocket(&evInfo->event, sizeof(display_event_t));
             CHECK_STATUS(status);

--- a/aic-emu/CmdHandler.cc
+++ b/aic-emu/CmdHandler.cc
@@ -31,6 +31,7 @@ CmdHandler::CmdHandler(AicConfigData_t& config):
     m_inputFileName(config.contentFileName),
     m_gfxDeviceStr(config.deviceString),
     m_props(nullptr),
+    m_manageFps(config.manageFps),
     m_lastDispReqSentTS(0),
     m_lastDispReqYmlTS(0),
     m_firstDispReqSentTS(0)
@@ -163,7 +164,7 @@ int CmdHandler::SendFDs(boData_t* bo_data)
 
 void CmdHandler::ManageDisplayReqTime(AicEventMetadataPtr& metadata)
 {
-    if (m_lastDispReqSentTS == 0)
+    if (!m_manageFps || m_lastDispReqSentTS == 0)
         return;
 
     long int waitTime = metadata->timeStampUs - m_lastDispReqYmlTS;

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -86,7 +86,6 @@ struct AicSocketData_t
     int session_id; //server session Id
     int user_id;    //user Id
     std::string hwc_sock; //socket path
-    int android_instance_id;
 };
 
 

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -122,6 +122,7 @@ struct AicConfigData_t
     std::string contentFileName;
     std::string deviceString;
     AicSocketData_t socketInfo;
+    bool        manageFps;
 };
 
 class CmdHandler
@@ -178,6 +179,7 @@ private:
     std::shared_ptr<cros_gralloc_handle> m_props;
 
     //fps management
+    bool                              m_manageFps;
     unsigned long                     m_lastDispReqSentTS;
     unsigned long                     m_lastDispReqYmlTS;
     unsigned long                     m_firstDispReqSentTS;

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -117,10 +117,18 @@ struct AicEventMetadata_t
     AicEventCounters counts;
 };
 
+struct AicConfigData_t
+{
+    std::string ymlFileName;
+    std::string contentFileName;
+    std::string deviceString;
+    AicSocketData_t socketInfo;
+};
+
 class CmdHandler
 {
 public:
-    CmdHandler(std::string ymlFile, std::string inputFile, AicSocketData_t* info);
+    CmdHandler(AicConfigData_t& config);
     ~CmdHandler();
 
     int Init();
@@ -164,6 +172,7 @@ private:
     //INPUT File and Gfx Surface Handling
     std::string                       m_inputFileName;
     std::ifstream                     m_inputStream;
+    std::string                       m_gfxDeviceStr;
     GfxHandler                        m_gfx;
 
     //Struct holding operating surface parameters

--- a/aic-emu/GfxHandler.h
+++ b/aic-emu/GfxHandler.h
@@ -125,6 +125,7 @@ public:
     GfxStatus DetermineSurfaceParams(SurfaceParams_t& surf, unsigned width,
                                       unsigned height, unsigned format);
     boData_t*  GetBo(uint64_t handle);
+    unsigned  GetRenderNode() { return m_renderNode; } ;
 
 protected:
 
@@ -139,12 +140,14 @@ protected:
     int        GetMmapType(boData_t* bo_gem = nullptr);
     size_t     GetPixelSize(unsigned int format);
     unsigned   GetTilingFormat(unsigned int format);
+    void       DetermineRenderNode();
 
     // State variables
     std::string                  m_device_str;
     int                          m_device_fd;
     GfxDeviceProps_t             m_device_props;
     std::map<uint64_t, boData_t> m_boList;
+    int                          m_renderNode = 0;
 };
 #endif
 

--- a/aic-emu/GfxHandler.h
+++ b/aic-emu/GfxHandler.h
@@ -113,10 +113,10 @@ class GfxHandler
 {
 public:
 
-    GfxHandler(const char* deviceStr = nullptr);
+    GfxHandler() {};
     ~GfxHandler();
 
-    GfxStatus GfxInit();
+    GfxStatus GfxInit(std::string deviceString);
     GfxStatus GfxClose();
     GfxStatus AllocateBo(SurfaceParams_t& surf, uint64_t handle);
     GfxStatus ClearBo(uint64_t handle, bool erase = true);


### PR DESCRIPTION
Related Issue: VSMGWL-60237

- Fix issue in passing device option to Gfx class
- Remove unnecessary restrictions on socket path
- Add following cmd line options to Aic-Emu: --manage-fps to control test fps settings, --instance to control session ID