### PR TITLE
aic-emu: Support for Resolution Change

### DIFF
--- a/aic-emu/AicEmu.cc
+++ b/aic-emu/AicEmu.cc
@@ -32,6 +32,8 @@ void Usage()
     std::cout << "  --device <device path>   : Device path. Default /dev/dri/renderD128" << std::endl;
     std::cout << "  --instance <id num>      : Number indicating instance ID. Default 0" << std::endl;
     std::cout << "  --manage-fps <0/1>       : Match fps with timestamps in yml log. Default Enabled(1)" << std::endl;
+    std::cout << "  --src-res <WidthxHeight> : Resolution of source content in 'WxH' units (in pixels units)\n"
+              << "                             Default: WxH interpreted from AIC cmd profile" << std::endl;
     return;
 }
 
@@ -80,6 +82,34 @@ int ParseArgs(AicConfigData_t& config, int argc, char** argv)
             if (++idx >= argc)
                 break;
             config.socketInfo.session_id = atoi(argv[idx]);
+        }
+        else if (std::string("--src-res") == argv[idx])
+        {
+            if (++idx >= argc)
+                break;
+            std::string srcRes(argv[idx]);
+            size_t pos = srcRes.find('x');
+            try
+            {
+                if (pos == std::string::npos) //not found
+                    throw std::invalid_argument("Unexpected src-res format");
+
+                std::string tmp = srcRes.substr(0, pos);
+                if (tmp.empty())
+                    throw std::invalid_argument("Unexpected src-res format");
+                config.srcWidth = atoi(tmp.c_str());
+
+                tmp = srcRes.substr(pos+1);
+                if (tmp.empty())
+                    throw std::invalid_argument("Unexpected src-res format");
+                config.srcHeight = atoi(tmp.c_str());
+            }
+            catch(const std::invalid_argument& e)
+            {
+                std::cout << "Warning: " << e.what() << " .. (Given: " << srcRes.c_str()
+                          << ") .. Proceeding with profile defaults" << std::endl;
+                config.srcWidth = config.srcHeight = 0;
+            }
         }
         else
         {

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -123,6 +123,8 @@ struct AicConfigData_t
     std::string deviceString;
     AicSocketData_t socketInfo;
     bool        manageFps;
+    unsigned int srcWidth;
+    unsigned int srcHeight;
 };
 
 class CmdHandler
@@ -132,10 +134,7 @@ public:
     ~CmdHandler();
 
     int Init();
-
     int ProcessNextEntry();
-
-
 
 private:
     //Init functions
@@ -147,8 +146,9 @@ private:
     int DecodeNode(YAML::Node& node, std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
 
     //INPUT File and Gfx Surface Handling + FPS management
-    int  GetOneFrame(uint8_t* pFrame, int sizeToRead);
+    int  GetOneFrame(uint8_t* pFrame, SurfaceParams_t surf);
     void ManageDisplayReqTime(AicEventMetadataPtr& metadata);
+    bool IsDirectRead(uint32_t gfx_w=0, uint32_t gfx_h=0);
 
     //Data to ICR
     int DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
@@ -174,6 +174,15 @@ private:
     std::ifstream                     m_inputStream;
     std::string                       m_gfxDeviceStr;
     GfxHandler                        m_gfx;
+
+    //Below parameters are required to be set to non-zero for tests where resolution changes, and for
+    //tests where the input stream resolution does not match the Input Profile resolution.
+    //-- If these are both 0, the input stream is assumed to have the dimensions for each frame accounted for.
+    //   If that is not the case, if can generate corrupt looking frames in the encoded stream
+    //-- The input stream resolution is required to be >= Max Resolution used in the Input Profile
+    //   For frames smaller this max resolution, the frame is simply cropped.
+    unsigned int                      m_srcWidth;
+    unsigned int                      m_srcHeight;
 
     //Struct holding operating surface parameters
     std::shared_ptr<cros_gralloc_handle> m_props;

--- a/aic-emu/CmdHandler.h
+++ b/aic-emu/CmdHandler.h
@@ -153,6 +153,7 @@ private:
     //Data to ICR
     int DataExchange(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
     int Xchng_DisplayRequest(std::vector<std::shared_ptr<void>>& payload, AicEventMetadataPtr& metadata);
+    int InitGfxSurfaceParams(SurfaceParams_t& surf);
 
     //Socket related Functions
     int WriteIntoSocket(void* data, uint32_t sizeInBytes);

--- a/aic-emu/GfxHandler.h
+++ b/aic-emu/GfxHandler.h
@@ -122,8 +122,7 @@ public:
     GfxStatus ClearBo(uint64_t handle, bool erase = true);
     GfxStatus Copy(boData_t* dstData, const void* srcBuf);
 
-    GfxStatus DetermineSurfaceParams(SurfaceParams_t& surf, unsigned width,
-                                      unsigned height, unsigned format);
+    GfxStatus AdjustSurfaceParams(SurfaceParams_t& surf);
     boData_t*  GetBo(uint64_t handle);
     unsigned  GetRenderNode() { return m_renderNode; } ;
 


### PR DESCRIPTION

This commit also supports cases where the test content supplied doesn't match the input profile resolution. 
- This is required to support tests where the game resolution changes
- Note that the app still expects the test clip to be larger than or equal to what the profile requires

A minor refactoring is done to support this: Moved surface parameter initialization into the CmdHandler class from the GfxHandler class, due to the former class having better access to the required data (width and stride parameters)

Related Jira: VSMGWL-51998
