### PR TITLE
Join all working threads of command channel handler

### DIFF
--- a/source/command_channel_interface_impl.h
+++ b/source/command_channel_interface_impl.h
@@ -308,6 +308,7 @@ public:
         should_continue_ = false;
         ams_talker_thread_.join();
         acs_talker_thread_.join();
+        ftc_talker_thread_.join();
     }
 
     IOResult SendDataPacket(MsgType msg_type, const uint8_t* message, size_t size)


### PR DESCRIPTION
Fixes: https://github.com/projectceladon/libvhal-client/issues/7

If one of the threads not joined program will get aborted with:
    terminate called without an active exception
    Aborted

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>