### PR TITLE
Add support to use port number provided by client

### DIFF
--- a/source/audio_sink.cc
+++ b/source/audio_sink.cc
@@ -39,7 +39,7 @@ AudioSink::AudioSink(TcpConnectionInfo tcp_conn_info, AudioCallback callback, co
 {
     auto tcp_sock_client =
       std::make_unique<TcpStreamSocketClient>(tcp_conn_info.ip_addr,
-      LIBVHAL_AUDIO_RECORD_PORT);
+      tcp_conn_info.port ? tcp_conn_info.port : LIBVHAL_AUDIO_RECORD_PORT);
     impl_ = std::make_unique<Impl>(std::move(tcp_sock_client), callback, user_id);
 }
 

--- a/source/audio_source.cc
+++ b/source/audio_source.cc
@@ -39,7 +39,7 @@ AudioSource::AudioSource(TcpConnectionInfo tcp_conn_info, AudioCallback callback
 {
     auto tcp_sock_client =
       std::make_unique<TcpStreamSocketClient>(tcp_conn_info.ip_addr,
-      LIBVHAL_AUDIO_PLAYBACK_PORT);
+      tcp_conn_info.port ? tcp_conn_info.port : LIBVHAL_AUDIO_PLAYBACK_PORT);
     impl_ = std::make_unique<Impl>(std::move(tcp_sock_client), callback, user_id);
 }
 


### PR DESCRIPTION
If port number is provided then use the given port number while creating audio_sink or audio_source object instead of using the hardcoded values.If it's not provided then use the hardcoded value.

Tracked-On: OAM-107287