### PR TITLE
Using std::move() for uci parameter.

### DIFF
--- a/examples/virtual_gps_receiver_sample.cc
+++ b/examples/virtual_gps_receiver_sample.cc
@@ -309,10 +309,11 @@ injection_gps_data_thread(void* args)
 
             // geo fix <longitude value> <latitude value>
             ret = do_geo_fix(lat_long);
-        } else { // ToDo
+        }
+        /* Example of inject nmea:
             char nmea[] = "";
             ret         = do_geo_nmea(nmea);
-        }
+        */
 
         if (ret < 0) {
             printf("%s Error: %d %s. Quit.\n", __func__, ret, strerror(errno));
@@ -397,7 +398,7 @@ main(int argc, char* argv[])
             case 's':
                 p_opt_arg = optarg;
                 strncpy(server_ip, p_opt_arg, sizeof(server_ip) - 1);
-                server_ip[sizeof(server_ip) -1] = '\0';
+                server_ip[sizeof(server_ip) - 1] = '\0';
                 break;
             case 'p':
                 p_opt_arg = optarg;
@@ -431,7 +432,7 @@ main(int argc, char* argv[])
     while (flag) {
         memset(str, 0, sizeof(str));
         printf("%s Please input comand('q' for quit):", __func__);
-	char *ret = fgets(str, 1, stdin);
+        char* ret = fgets(str, 1, stdin);
         if (ret == NULL) {
             printf("%s Fail to get input. Continue. \n", __func__);
             continue;

--- a/examples/virtual_input_receiver_sample.cc
+++ b/examples/virtual_input_receiver_sample.cc
@@ -551,7 +551,7 @@ main(int argc, char* argv[])
 
     struct UnixConnectionInfo uci;
     uci.socket_dir            = kDevNameId;
-    VirtualInputReceiver* vir = new VirtualInputReceiver(uci);
+    VirtualInputReceiver* vir = new VirtualInputReceiver(std::move(uci));
     if ((debug & 0x1) > 0)
         printf("\t%s:%d Remote input test:\n", __func__, __LINE__);
 

--- a/include/libvhal/virtual_gps_receiver.h
+++ b/include/libvhal/virtual_gps_receiver.h
@@ -57,6 +57,8 @@ public:
      */
     VirtualGpsReceiver(struct TcpConnectionInfo tci, GpsCommandHandler gch);
     ~VirtualGpsReceiver();
+    VirtualGpsReceiver(VirtualGpsReceiver &) = delete;
+    VirtualGpsReceiver& operator = (VirtualGpsReceiver &) = delete;
 
     /**
      * @brief Connect to remote endpoint.
@@ -120,7 +122,7 @@ private:
     GpsCommandHandler            mGpsCmdHandler = nullptr;
     int                          mSockGps       = -1;
     static const char*           kGpsSock;
-    volatile Command             mCommand;
+    volatile Command             mCommand = kGpsStop;
     std::unique_ptr<std::thread> mWorkThread;
     std::mutex                   mMutex;
     bool                         mStop = false;

--- a/include/libvhal/virtual_input_receiver.h
+++ b/include/libvhal/virtual_input_receiver.h
@@ -41,6 +41,8 @@ public:
      */
     VirtualInputReceiver(struct UnixConnectionInfo uci);
     virtual ~VirtualInputReceiver();
+    VirtualInputReceiver(VirtualInputReceiver &) = delete;
+    VirtualInputReceiver& operator = (VirtualInputReceiver &) = delete;
 
     bool     getTouchInfo(TouchInfo* info) override;
     IOResult onInputMessage(const std::string& msg) override;

--- a/source/virtual_gps_receiver.cc
+++ b/source/virtual_gps_receiver.cc
@@ -40,8 +40,8 @@ const std::string VirtualGpsReceiver::gpsStopMsg = "{ \"key\" : \"gps-stop\" }";
 const unsigned int VirtualGpsReceiver::mDebug    = 0;
 
 VirtualGpsReceiver::VirtualGpsReceiver(struct TcpConnectionInfo tci, GpsCommandHandler gch) 
-  : mTci(tci),
-    mGpsCmdHandler{ move(gch) }
+  : mTci(std::move(tci)),
+    mGpsCmdHandler{ std::move(gch) }
 {
     mWorkThread = std::unique_ptr<std::thread>(
       new std::thread(&VirtualGpsReceiver::workThreadProc, this));


### PR DESCRIPTION
uci parameter use std::move().
Reset mFd to -1 in decontractor.

Tracked-On: OAM-110937
Change-Id: I5e10077e1a73d77315115cf65c764158ddb72772